### PR TITLE
chore: add named volume & root install libgssapi

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,7 @@
             ConnectionStrings__DefaultConnection: Host=db;Port=5432;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}
         volumes:
             - ./uploads:/app/wwwroot/img/uploads
-            - ./dataprotection-keys:/home/app/.aspnet/DataProtection-Keys
+            - suryami62-dpkeys:/home/app/.aspnet/DataProtection-Keys
         networks:
             - backend
 
@@ -34,7 +34,7 @@
         networks:
             - backend
         healthcheck:
-            test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}" ]
+            test: [ "CMD-SHELL", "pg_isready -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\"" ]
             interval: 10s
             timeout: 5s
             retries: 5
@@ -45,3 +45,4 @@ networks:
 
 volumes:
     suryami62-db:
+    suryami62-dpkeys:

--- a/suryami62/Dockerfile
+++ b/suryami62/Dockerfile
@@ -1,8 +1,19 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
-USER $APP_UID
+USER root
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
+
+# Install native dependency required by Npgsql for GSS/Kerberos auth negotiation.
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends libgssapi-krb5-2 \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Ensure runtime-writable directories exist for non-root user.
+RUN mkdir -p /home/app/.aspnet/DataProtection-Keys /app/wwwroot/img/uploads \
+	&& chown -R $APP_UID:0 /home/app/.aspnet /app/wwwroot
+
+USER $APP_UID
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release

--- a/suryami62/Dockerfile
+++ b/suryami62/Dockerfile
@@ -3,16 +3,11 @@ USER root
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
-
-# Install native dependency required by Npgsql for GSS/Kerberos auth negotiation.
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends libgssapi-krb5-2 \
-	&& rm -rf /var/lib/apt/lists/*
-
-# Ensure runtime-writable directories exist for non-root user.
-RUN mkdir -p /home/app/.aspnet/DataProtection-Keys /app/wwwroot/img/uploads \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& mkdir -p /home/app/.aspnet/DataProtection-Keys /app/wwwroot/img/uploads \
 	&& chown -R $APP_UID:0 /home/app/.aspnet /app/wwwroot
-
 USER $APP_UID
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build


### PR DESCRIPTION
- Switch data protection to a named volume, quote PostgreSQL environment variables in the healthcheck command, and add the new volume declaration.
- Switch to root to install the libgssapi‑krb5‑2 dependency and create runtime‑writable directories, then revert to the non‑root application UID.