### PR TITLE
feat: add SELinux label, URL encoding, dir setup

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -15,7 +15,7 @@
         environment:
             ConnectionStrings__DefaultConnection: Host=db;Port=5432;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}
         volumes:
-            - ./uploads:/app/wwwroot/img/uploads
+            - ./uploads:/app/wwwroot/img/uploads:Z
             - suryami62-dpkeys:/home/app/.aspnet/DataProtection-Keys
         networks:
             - backend

--- a/suryami62/Components/Account/Pages/Admin/Media.razor
+++ b/suryami62/Components/Account/Pages/Admin/Media.razor
@@ -56,7 +56,7 @@
                 <div class="neo-card group relative overflow-hidden border-2">
                     <div
                         class="aspect-square bg-gray-100 dark:bg-gray-800 overflow-hidden border-b-2 border-black dark:border-white">
-                        <img src="img/uploads/@file" alt="@file" loading="lazy"
+                        <img src="/img/uploads/@ToEncodedUrlSegment(file)" alt="@file" loading="lazy"
                              class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110"/>
                     </div>
                     <div class="p-3 flex flex-col gap-3">
@@ -173,7 +173,7 @@
 
     private async Task CopyToClipboard(string filename)
     {
-        var relativeUrl = $"img/uploads/{filename}";
+        var relativeUrl = $"/img/uploads/{ToEncodedUrlSegment(filename)}";
         var absoluteUrl = NavigationManager.ToAbsoluteUri(relativeUrl).ToString();
 
         try
@@ -195,6 +195,11 @@
             _statusMessage = "Error: JavaScript interop failed.";
             _isError = true;
         }
+    }
+
+    private static string ToEncodedUrlSegment(string fileName)
+    {
+        return Uri.EscapeDataString(Uri.UnescapeDataString(fileName));
     }
 
 }

--- a/suryami62/Dockerfile
+++ b/suryami62/Dockerfile
@@ -5,10 +5,7 @@ EXPOSE 8080
 EXPOSE 8081
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends libgssapi-krb5-2 \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& mkdir -p /home/app/.aspnet/DataProtection-Keys /app/wwwroot/img/uploads \
-	&& chown -R $APP_UID:0 /home/app/.aspnet /app/wwwroot
-USER $APP_UID
+	&& rm -rf /var/lib/apt/lists/*
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
@@ -29,4 +26,8 @@ RUN dotnet publish "./suryami62.csproj" -c $BUILD_CONFIGURATION -o /app/publish 
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+RUN mkdir -p /home/app/.aspnet/DataProtection-Keys /app/wwwroot/img/uploads \
+	&& chown -R $APP_UID:0 /home/app/.aspnet /app/wwwroot/img/uploads \
+	&& chmod -R 775 /app/wwwroot/img/uploads
+USER $APP_UID
 ENTRYPOINT ["dotnet", "suryami62.dll"]

--- a/suryami62/Dockerfile
+++ b/suryami62/Dockerfile
@@ -27,7 +27,7 @@ FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 RUN mkdir -p /home/app/.aspnet/DataProtection-Keys /app/wwwroot/img/uploads \
-	&& chown -R $APP_UID:0 /home/app/.aspnet /app/wwwroot/img/uploads \
+	&& chown -R "$APP_UID:0" /home/app/.aspnet /app/wwwroot/img/uploads \
 	&& chmod -R 775 /app/wwwroot/img/uploads
 USER $APP_UID
 ENTRYPOINT ["dotnet", "suryami62.dll"]

--- a/suryami62/Program.cs
+++ b/suryami62/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using suryami62.Application;
 using suryami62.Application.Persistence;
@@ -70,6 +71,14 @@ else
 
 app.UseStatusCodePagesWithReExecute("/not-found", createScopeForStatusCodePages: true);
 app.UseHttpsRedirection();
+
+var uploadsPath = Path.Combine(app.Environment.WebRootPath, "img", "uploads");
+Directory.CreateDirectory(uploadsPath);
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = new PhysicalFileProvider(uploadsPath),
+    RequestPath = "/img/uploads"
+});
 
 app.UseAntiforgery();
 

--- a/suryami62/Services/MediaService.cs
+++ b/suryami62/Services/MediaService.cs
@@ -1,6 +1,7 @@
 #region
 
 using System.Globalization;
+using System.Text;
 
 #endregion
 
@@ -8,6 +9,8 @@ namespace suryami62.Services;
 
 internal sealed class MediaService(IWebHostEnvironment webHostEnvironment) : IMediaService
 {
+    private const int MaxSeoFileNameLength = 80;
+
     private static readonly HashSet<string> AllowedExtensions = new(StringComparer.OrdinalIgnoreCase)
     {
         ".jpg",
@@ -49,6 +52,9 @@ internal sealed class MediaService(IWebHostEnvironment webHostEnvironment) : IMe
             var extension = Path.GetExtension(safeFileName);
             if (!AllowedExtensions.Contains(extension))
                 return new UploadResult(false, $"Extension '{extension}' is not allowed.");
+
+            safeFileName = BuildUrlEncodedFileName(safeFileName);
+            if (string.IsNullOrWhiteSpace(safeFileName)) return new UploadResult(false, "Invalid file name.");
 
             if (!AllowedContentTypes.Contains(contentType))
                 return new UploadResult(false, $"Content type '{contentType}' is not allowed.");
@@ -145,5 +151,50 @@ internal sealed class MediaService(IWebHostEnvironment webHostEnvironment) : IMe
         }
 
         return (true, string.Empty);
+    }
+
+    private static string BuildUrlEncodedFileName(string fileName)
+    {
+        var nameWithoutExtension = Path.GetFileNameWithoutExtension(fileName).Trim();
+        if (string.IsNullOrWhiteSpace(nameWithoutExtension)) return string.Empty;
+
+        var seoFriendlyName = BuildSeoFriendlyName(nameWithoutExtension);
+        if (seoFriendlyName.Length > MaxSeoFileNameLength)
+            seoFriendlyName = seoFriendlyName[..MaxSeoFileNameLength].Trim('-');
+        if (string.IsNullOrWhiteSpace(seoFriendlyName)) seoFriendlyName = "image";
+
+        var extension = Path.GetExtension(fileName);
+        var encodedName = Uri.EscapeDataString(seoFriendlyName);
+
+        return $"{encodedName}{extension}";
+    }
+
+    private static string BuildSeoFriendlyName(string input)
+    {
+        var normalized = input.Normalize(NormalizationForm.FormD);
+        var sb = new StringBuilder(normalized.Length);
+        var lastWasDash = false;
+
+        foreach (var c in normalized)
+        {
+            var category = CharUnicodeInfo.GetUnicodeCategory(c);
+            if (category == UnicodeCategory.NonSpacingMark) continue;
+
+            if (char.IsLetterOrDigit(c))
+            {
+                sb.Append(char.ToLowerInvariant(c));
+                lastWasDash = false;
+                continue;
+            }
+
+            if (char.IsWhiteSpace(c) || c is '-' or '_')
+                if (!lastWasDash && sb.Length > 0)
+                {
+                    sb.Append('-');
+                    lastWasDash = true;
+                }
+        }
+
+        return sb.ToString().Trim('-');
     }
 }

--- a/suryami62/Services/MediaService.cs
+++ b/suryami62/Services/MediaService.cs
@@ -187,12 +187,11 @@ internal sealed class MediaService(IWebHostEnvironment webHostEnvironment) : IMe
                 continue;
             }
 
-            if (char.IsWhiteSpace(c) || c is '-' or '_')
-                if (!lastWasDash && sb.Length > 0)
-                {
-                    sb.Append('-');
-                    lastWasDash = true;
-                }
+            if ((char.IsWhiteSpace(c) || c is '-' or '_') && !lastWasDash && sb.Length > 0)
+            {
+                sb.Append('-');
+                lastWasDash = true;
+            }
         }
 
         return sb.ToString().Trim('-');


### PR DESCRIPTION
- Add SELinux :Z label to the uploads volume mount.
- Encode image filenames in URLs by using a ToEncodedUrlSegment method for image src attributes and clipboard links, and add a static helper to perform URL segment encoding.
- Create necessary application directories, set their ownership and permissions, and switch to the non‑root user in the final image stage.
- Add static file provider to serve uploaded images from /img/uploads.
- Add SEO‑friendly URL‑encoded file name generation with length limit and validation in the media service.