### PR TITLE
fix: Always call KeyDeleteAsync without empty check

### DIFF
--- a/suryami62/Services/RedisCacheService.cs
+++ b/suryami62/Services/RedisCacheService.cs
@@ -73,6 +73,6 @@ internal sealed class RedisCacheService : IRedisCacheService, IDisposable
 
         await foreach (var key in server.KeysAsync(pattern: pattern).ConfigureAwait(false)) keyList.Add(key);
 
-        if (keyList.Count != 0) await _database.KeyDeleteAsync(keyList.ToArray()).ConfigureAwait(false);
+        await _database.KeyDeleteAsync(keyList.ToArray()).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
- Always invoke KeyDeleteAsync for the key list without checking for emptiness.