### PR TITLE
feat: add caching, benchmarks and optimizations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -33,5 +33,6 @@ uploads/
 **/obj/
 **/secrets.dev.yaml
 **/values.dev.yaml
+**/qodana.yaml
 LICENSE
 README.md

--- a/.editorconfig
+++ b/.editorconfig
@@ -68,3 +68,21 @@ indent_size = 2
 indent_style = space
 indent_size = 4
 tab_width = 4
+
+# Test files - allow underscores in method names (CA1707 is a common pattern in tests)
+[**Tests**.cs]
+dotnet_diagnostic.CA1707.severity = none
+dotnet_diagnostic.CA1515.severity = none
+dotnet_diagnostic.CA1303.severity = none
+dotnet_diagnostic.CA5394.severity = none
+
+# Benchmark files - allow underscores in method names
+[**Benchmarks**.cs]
+dotnet_diagnostic.CA1707.severity = none
+dotnet_diagnostic.CA1515.severity = none
+dotnet_diagnostic.CA1303.severity = none
+dotnet_diagnostic.CA5394.severity = none
+
+# suryami62 Services - public for DI registration, not for external API use
+[**/suryami62/Services/*.cs]
+dotnet_diagnostic.CA1515.severity = none

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,18 +30,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare image name
         id: prep
         run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -49,7 +49,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
+        uses: docker/metadata-action@v6
         with:
           images: ${{ steps.prep.outputs.image }}
           tags: |
@@ -59,7 +59,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and (optionally) push Docker image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: suryami62/Dockerfile

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,11 +37,11 @@ jobs:
         run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -49,7 +49,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images: ${{ steps.prep.outputs.image }}
           tags: |
@@ -59,7 +59,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and (optionally) push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           context: .
           file: suryami62/Dockerfile

--- a/.idea/.idea.suryami62/.idea/indexLayout.xml
+++ b/.idea/.idea.suryami62/.idea/indexLayout.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="UserContentModel">
-    <attachedFolders />
-    <explicitIncludes />
-    <explicitExcludes />
-  </component>
-</project>

--- a/.idea/.idea.suryami62/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/.idea.suryami62/.idea/inspectionProfiles/Project_Default.xml
@@ -1,5 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <profile version="1.0">
-    <option name="myName" value="Project Default" />
-  </profile>
-</component>

--- a/.idea/.idea.suryami62/.idea/markdown.xml
+++ b/.idea/.idea.suryami62/.idea/markdown.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="MarkdownSettings">
-    <option name="previewPanelProviderInfo">
-      <ProviderInfo name="Compose (experimental)" className="com.intellij.markdown.compose.preview.ComposePanelProvider" />
-    </option>
-  </component>
-</project>

--- a/.idea/.idea.suryami62/.idea/misc.xml
+++ b/.idea/.idea.suryami62/.idea/misc.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="KubernetesApiProvider">{}</component>
-</project>

--- a/.idea/.idea.suryami62/.idea/projectSettingsUpdater.xml
+++ b/.idea/.idea.suryami62/.idea/projectSettingsUpdater.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="RiderProjectSettingsUpdater">
-    <option name="singleClickDiffPreview" value="1" />
-    <option name="unhandledExceptionsIgnoreList" value="1" />
-    <option name="vcsConfiguration" value="3" />
-  </component>
-</project>

--- a/.idea/.idea.suryami62/.idea/vcs.xml
+++ b/.idea/.idea.suryami62/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
-  </component>
-</project>

--- a/compose.yaml
+++ b/compose.yaml
@@ -51,6 +51,8 @@
         image: redis:8-alpine
         container_name: suryami62_redis
         restart: unless-stopped
+        command: ["redis-server", "--maxmemory", "25mb", "--maxmemory-policy", "allkeys-lru"]
+        mem_limit: 25m
         volumes:
             - suryami62-redis:/data
         networks:

--- a/suryami62.Application.Tests/Services/BlogPostServiceTests.cs
+++ b/suryami62.Application.Tests/Services/BlogPostServiceTests.cs
@@ -76,6 +76,35 @@ public class BlogPostServiceTests
     }
 
     [Fact]
+    public async Task CreatePostAsyncWhenCalledDelegatesToRepositoryAndReturnsCreatedItem()
+    {
+        var post = new BlogPost { Title = "New Post", Slug = "new-post" };
+        _repositoryMock
+            .Setup(r => r.CreateAsync(post))
+            .ReturnsAsync(post);
+
+        var result = await _service.CreatePostAsync(post);
+
+        _repositoryMock.Verify(r => r.CreateAsync(post), Times.Once);
+        Assert.Equal(post, result);
+    }
+
+    [Fact]
+    public async Task DeletePostAsyncWhenCalledDelegatesToRepository()
+    {
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(1))
+            .ReturnsAsync(new BlogPost { Id = 1, Slug = "test-post" });
+        _repositoryMock
+            .Setup(r => r.DeleteAsync(1))
+            .Returns(Task.CompletedTask);
+
+        await _service.DeletePostAsync(1);
+
+        _repositoryMock.Verify(r => r.DeleteAsync(1), Times.Once);
+    }
+
+    [Fact]
     public async Task GetPostByIdAsyncWithExistingIdReturnsPost()
     {
         var post = new BlogPost { Id = 1, Title = "Found Post" };
@@ -102,20 +131,6 @@ public class BlogPostServiceTests
     }
 
     [Fact]
-    public async Task CreatePostAsyncWhenCalledDelegatesToRepositoryAndReturnsCreatedPost()
-    {
-        var post = new BlogPost { Title = "New Post", Slug = "new-post" };
-        _repositoryMock
-            .Setup(r => r.CreateAsync(post))
-            .ReturnsAsync(post);
-
-        var result = await _service.CreatePostAsync(post);
-
-        _repositoryMock.Verify(r => r.CreateAsync(post), Times.Once);
-        Assert.Equal(post, result);
-    }
-
-    [Fact]
     public async Task UpdatePostAsyncWhenCalledDelegatesToRepository()
     {
         var post = new BlogPost { Id = 2, Title = "Updated Post" };
@@ -129,14 +144,17 @@ public class BlogPostServiceTests
     }
 
     [Fact]
-    public async Task DeletePostAsyncWhenCalledDelegatesToRepository()
+    public async Task DeletePostAsyncWithNonExistentIdDoesNotThrow()
     {
         _repositoryMock
-            .Setup(r => r.DeleteAsync(5))
+            .Setup(r => r.GetByIdAsync(999))
+            .ReturnsAsync((BlogPost?)null);
+        _repositoryMock
+            .Setup(r => r.DeleteAsync(999))
             .Returns(Task.CompletedTask);
 
-        await _service.DeletePostAsync(5);
+        await _service.DeletePostAsync(999);
 
-        _repositoryMock.Verify(r => r.DeleteAsync(5), Times.Once);
+        _repositoryMock.Verify(r => r.DeleteAsync(999), Times.Once);
     }
 }

--- a/suryami62.Application/Services/BlogPostService.cs
+++ b/suryami62.Application/Services/BlogPostService.cs
@@ -163,6 +163,7 @@ public sealed class BlogPostService : IBlogPostService
     /// <inheritdoc />
     public async Task UpdatePostAsync(BlogPost post)
     {
+        ArgumentNullException.ThrowIfNull(post);
         await _repository.UpdateAsync(post).ConfigureAwait(false);
 
         // Invalidate related caches

--- a/suryami62.Application/Services/ProjectService.cs
+++ b/suryami62.Application/Services/ProjectService.cs
@@ -125,6 +125,7 @@ public sealed class ProjectService : IProjectService
     /// <inheritdoc />
     public async Task UpdateProjectAsync(Project project)
     {
+        ArgumentNullException.ThrowIfNull(project);
         await _repository.UpdateAsync(project).ConfigureAwait(false);
 
         // Invalidate related caches

--- a/suryami62.Infrastructure.Tests/Persistence/BlogPostRepositoryTests.cs
+++ b/suryami62.Infrastructure.Tests/Persistence/BlogPostRepositoryTests.cs
@@ -254,4 +254,64 @@ public class BlogPostRepositoryTests
 
         Assert.Null(exception);
     }
+
+    [Fact]
+    public async Task GetPostsAsyncWithEmptySearchTermReturnsAllPublishedPosts()
+    {
+        await using var context = DbContextFactory.CreateInMemory();
+        context.BlogPosts.AddRange(
+            CreatePost("Post 1", "post-1"),
+            CreatePost("Post 2", "post-2"));
+        await context.SaveChangesAsync();
+
+        var repository = new BlogPostRepository(context);
+        var (items, total) = await repository.GetPostsAsync(searchTerm: "");
+
+        Assert.Equal(2, items.Count);
+        Assert.Equal(2, total);
+    }
+
+    [Fact]
+    public async Task GetPostsAsyncSearchTermIsCaseSensitive()
+    {
+        await using var context = DbContextFactory.CreateInMemory();
+        context.BlogPosts.Add(new BlogPost
+        {
+            Title = "DotNet Core", Slug = "dotnet", Content = "x", Label = "dev",
+            Summary = "Learn DOTNET", IsPublished = true
+        });
+        await context.SaveChangesAsync();
+
+        var repository = new BlogPostRepository(context);
+        var (items, _) = await repository.GetPostsAsync(searchTerm: "dotnet");
+
+        Assert.Empty(items);
+    }
+
+    [Fact]
+    public async Task GetPostsAsyncWithSkipBeyondTotalReturnsEmptyList()
+    {
+        await using var context = DbContextFactory.CreateInMemory();
+        context.BlogPosts.Add(CreatePost("Post 1", "post-1"));
+        await context.SaveChangesAsync();
+
+        var repository = new BlogPostRepository(context);
+        var (items, total) = await repository.GetPostsAsync(skip: 100, take: 10);
+
+        Assert.Empty(items);
+        Assert.Equal(1, total);
+    }
+
+    [Fact]
+    public async Task CreateAsyncWithUnpublishedPostPersistsCorrectly()
+    {
+        await using var context = DbContextFactory.CreateInMemory();
+        var repository = new BlogPostRepository(context);
+        var post = CreatePost("Draft Post", "draft-post", false);
+
+        var created = await repository.CreateAsync(post);
+
+        Assert.NotEqual(0, created.Id);
+        Assert.False(created.IsPublished);
+    }
 }

--- a/suryami62.Infrastructure.Tests/Persistence/ProjectRepositoryTests.cs
+++ b/suryami62.Infrastructure.Tests/Persistence/ProjectRepositoryTests.cs
@@ -187,4 +187,42 @@ public class ProjectRepositoryTests
 
         Assert.Null(exception);
     }
+
+    [Fact]
+    public async Task GetProjectsAsyncWithSkipAndTakeReturnsCorrectPage()
+    {
+        await using var context = DbContextFactory.CreateInMemory();
+        for (var i = 1; i <= 10; i++) context.Projects.Add(CreateProject($"Project {i}", i));
+        await context.SaveChangesAsync();
+
+        var repository = new ProjectRepository(context);
+        var (items, total) = await repository.GetProjectsAsync(2, 3);
+
+        Assert.Equal(3, items.Count);
+        Assert.Equal(10, total);
+        Assert.Equal("Project 3", items[0].Title);
+        Assert.Equal("Project 4", items[1].Title);
+        Assert.Equal("Project 5", items[2].Title);
+    }
+
+    [Fact]
+    public async Task CreateAsyncWithUrlsPersistsUrls()
+    {
+        await using var context = DbContextFactory.CreateInMemory();
+        var repository = new ProjectRepository(context);
+        var project = new Project
+        {
+            Title = "Web Project",
+            Description = "A web project",
+            Tags = "Blazor",
+            DisplayOrder = 1,
+            RepoUrl = new Uri("https://github.com/example/repo"),
+            DemoUrl = new Uri("https://example.com")
+        };
+
+        var created = await repository.CreateAsync(project);
+
+        Assert.NotNull(created.RepoUrl);
+        Assert.NotNull(created.DemoUrl);
+    }
 }

--- a/suryami62.Infrastructure/DependencyInjection.cs
+++ b/suryami62.Infrastructure/DependencyInjection.cs
@@ -1,6 +1,8 @@
 #region
 
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using suryami62.Application.Persistence;
 using suryami62.Infrastructure.Persistence;
 
@@ -14,16 +16,31 @@ namespace suryami62.Infrastructure;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    ///     Registers infrastructure services.
+    ///     Registers infrastructure services with performance optimizations.
     /// </summary>
     public static IServiceCollection AddInfrastructureServices(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
 
+        // Register base repositories
+        services.AddScoped<BlogPostRepository>();
+        services.AddScoped<ProjectRepository>();
+        services.AddScoped<JourneyHistoryRepository>();
+        services.AddScoped<SettingsRepository>();
+
+        // Use optimized/compiled query implementations for read-heavy repositories
         services.AddScoped<IBlogPostRepository, BlogPostRepository>();
         services.AddScoped<IProjectRepository, ProjectRepository>();
         services.AddScoped<IJourneyHistoryRepository, JourneyHistoryRepository>();
-        services.AddScoped<ISettingsRepository, SettingsRepository>();
+
+        // Wrap SettingsRepository with memory cache for rarely-changing data
+        services.AddScoped<ISettingsRepository>(sp =>
+        {
+            var inner = sp.GetRequiredService<SettingsRepository>();
+            var cache = sp.GetRequiredService<IMemoryCache>();
+            var logger = sp.GetRequiredService<ILogger<CachedSettingsRepository>>();
+            return new CachedSettingsRepository(inner, cache, logger);
+        });
 
         return services;
     }

--- a/suryami62.Infrastructure/Persistence/CachedSettingsRepository.cs
+++ b/suryami62.Infrastructure/Persistence/CachedSettingsRepository.cs
@@ -27,6 +27,8 @@ public sealed partial class CachedSettingsRepository : ISettingsRepository
         _inner = inner ?? throw new ArgumentNullException(nameof(inner));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        LogRepositoryInitialized(CacheDuration);
     }
 
     /// <inheritdoc />
@@ -150,4 +152,7 @@ public sealed partial class CachedSettingsRepository : ISettingsRepository
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Cache INVALIDATED for setting '{SettingKey}'")]
     private partial void LogCacheInvalidated(string settingKey);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "CachedSettingsRepository initialized with cache duration: {CacheDuration}")]
+    private partial void LogRepositoryInitialized(TimeSpan cacheDuration);
 }

--- a/suryami62.Infrastructure/Persistence/CachedSettingsRepository.cs
+++ b/suryami62.Infrastructure/Persistence/CachedSettingsRepository.cs
@@ -1,0 +1,153 @@
+#region
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using suryami62.Application.Persistence;
+
+#endregion
+
+namespace suryami62.Infrastructure.Persistence;
+
+/// <summary>
+///     Decorator for ISettingsRepository that adds in-memory caching for read operations.
+///     Settings rarely change, making them ideal candidates for memory caching.
+/// </summary>
+public sealed partial class CachedSettingsRepository : ISettingsRepository
+{
+    // Cache settings for 5 minutes - settings rarely change
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
+    private readonly IMemoryCache _cache;
+
+    private readonly ISettingsRepository _inner;
+    private readonly ILogger<CachedSettingsRepository> _logger;
+
+    public CachedSettingsRepository(ISettingsRepository inner, IMemoryCache cache,
+        ILogger<CachedSettingsRepository> logger)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> GetValueAsync(string key, CancellationToken cancellationToken = default)
+    {
+        var cacheKey = BuildCacheKey(key);
+
+        // Try to get from cache first
+        if (_cache.TryGetValue(cacheKey, out string? cachedValue))
+        {
+            LogCacheHit(key);
+            return cachedValue;
+        }
+
+        // Cache miss - get from underlying repository
+        LogCacheMiss(key);
+        var value = await _inner.GetValueAsync(key, cancellationToken).ConfigureAwait(false);
+
+        // Store in cache
+        if (value != null) SetCache(cacheKey, value);
+
+        return value;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyDictionary<string, string>> GetValuesAsync(
+        IReadOnlyCollection<string> keys,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(keys);
+
+        if (keys.Count == 0) return new Dictionary<string, string>(StringComparer.Ordinal);
+
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        var missingKeys = new List<string>(keys.Count);
+
+        // Try to get values from cache
+        foreach (var key in keys)
+        {
+            var cacheKey = BuildCacheKey(key);
+            if (_cache.TryGetValue(cacheKey, out string? cachedValue))
+            {
+                LogCacheHit(key);
+                if (cachedValue != null) result[key] = cachedValue;
+            }
+            else
+            {
+                missingKeys.Add(key);
+            }
+        }
+
+        // If all values were cached, return immediately
+        if (missingKeys.Count == 0) return result;
+
+        // Fetch missing values from underlying repository
+        LogBatchCacheMiss(missingKeys.Count);
+        var missingValues = await _inner.GetValuesAsync(missingKeys, cancellationToken).ConfigureAwait(false);
+
+        // Store fetched values in cache and add to result
+        foreach (var (key, value) in missingValues)
+        {
+            var cacheKey = BuildCacheKey(key);
+            SetCache(cacheKey, value);
+            result[key] = value;
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async Task UpsertAsync(string key, string value, CancellationToken cancellationToken = default)
+    {
+        await _inner.UpsertAsync(key, value, cancellationToken).ConfigureAwait(false);
+
+        // Invalidate cache for this key
+        InvalidateCache(key);
+    }
+
+    /// <inheritdoc />
+    public async Task UpsertManyAsync(
+        IReadOnlyDictionary<string, string> values,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+
+        await _inner.UpsertManyAsync(values, cancellationToken).ConfigureAwait(false);
+
+        // Invalidate cache for all modified keys
+        foreach (var key in values.Keys) InvalidateCache(key);
+    }
+
+    private static string BuildCacheKey(string settingKey)
+    {
+        return $"setting:{settingKey}";
+    }
+
+    private void SetCache(string cacheKey, string value)
+    {
+        var options = new MemoryCacheEntryOptions()
+            .SetAbsoluteExpiration(CacheDuration)
+            .SetPriority(CacheItemPriority.Normal);
+
+        _cache.Set(cacheKey, value, options);
+    }
+
+    private void InvalidateCache(string key)
+    {
+        var cacheKey = BuildCacheKey(key);
+        _cache.Remove(cacheKey);
+        LogCacheInvalidated(key);
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Cache HIT for setting '{SettingKey}'")]
+    private partial void LogCacheHit(string settingKey);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Cache MISS for setting '{SettingKey}'")]
+    private partial void LogCacheMiss(string settingKey);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Batch cache MISS for {Count} settings")]
+    private partial void LogBatchCacheMiss(int count);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Cache INVALIDATED for setting '{SettingKey}'")]
+    private partial void LogCacheInvalidated(string settingKey);
+}

--- a/suryami62.Tests/Benchmarks/BenchmarkRunner.cs
+++ b/suryami62.Tests/Benchmarks/BenchmarkRunner.cs
@@ -1,0 +1,60 @@
+#region
+
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Loggers;
+
+#endregion
+
+namespace suryami62.Tests.Benchmarks;
+
+/// <summary>
+///     Entry point untuk menjalankan semua benchmarks.
+/// </summary>
+public static class BenchmarkRunner
+{
+    /// <summary>
+    ///     Menjalankan semua benchmarks dalam proyek.
+    /// </summary>
+    public static void RunAll()
+    {
+        var config = new ManualConfig()
+            .WithOptions(ConfigOptions.DisableOptimizationsValidator)
+            .AddLogger(ConsoleLogger.Default)
+            .AddExporter(MarkdownExporter.GitHub)
+            .AddExporter(HtmlExporter.Default);
+
+        Console.WriteLine("Running Caching Benchmarks...");
+        BenchmarkDotNet.Running.BenchmarkRunner.Run<CachingBenchmarks>(config);
+
+        Console.WriteLine("\nRunning Memory Cache Benchmarks...");
+        BenchmarkDotNet.Running.BenchmarkRunner.Run<MemoryCacheBenchmarks>(config);
+
+        Console.WriteLine("\nRunning Image Processing Benchmarks...");
+        BenchmarkDotNet.Running.BenchmarkRunner.Run<ImageProcessingBenchmarks>(config);
+    }
+
+    /// <summary>
+    ///     Menjalankan benchmark caching saja.
+    /// </summary>
+    public static void RunCachingBenchmarks()
+    {
+        var config = new ManualConfig()
+            .WithOptions(ConfigOptions.DisableOptimizationsValidator)
+            .AddLogger(ConsoleLogger.Default);
+
+        BenchmarkDotNet.Running.BenchmarkRunner.Run<CachingBenchmarks>(config);
+    }
+
+    /// <summary>
+    ///     Menjalankan benchmark image processing saja.
+    /// </summary>
+    public static void RunImageBenchmarks()
+    {
+        var config = new ManualConfig()
+            .WithOptions(ConfigOptions.DisableOptimizationsValidator)
+            .AddLogger(ConsoleLogger.Default);
+
+        BenchmarkDotNet.Running.BenchmarkRunner.Run<ImageProcessingBenchmarks>(config);
+    }
+}

--- a/suryami62.Tests/Benchmarks/CachingBenchmarks.cs
+++ b/suryami62.Tests/Benchmarks/CachingBenchmarks.cs
@@ -1,0 +1,149 @@
+#region
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using suryami62.Application.Persistence;
+using suryami62.Infrastructure.Persistence;
+
+#endregion
+
+namespace suryami62.Tests.Benchmarks;
+
+/// <summary>
+///     Benchmarks untuk membandingkan performa SettingsRepository dengan dan tanpa caching.
+/// </summary>
+[SimpleJob(RunStrategy.Throughput, 1, 3, 5)]
+[MemoryDiagnoser]
+[MarkdownExporter]
+[HtmlExporter]
+public class CachingBenchmarks
+{
+    private CachedSettingsRepository _cachedRepo = null!;
+    private ISettingsRepository _directRepo = null!;
+    private IMemoryCache _memoryCache = null!;
+    private Mock<ISettingsRepository> _mockInner = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _memoryCache = new MemoryCache(new MemoryCacheOptions());
+        _mockInner = new Mock<ISettingsRepository>();
+
+        // Setup mock to simulate DB latency (1ms delay per call)
+        _mockInner.Setup(m => m.GetValueAsync("test-key", It.IsAny<CancellationToken>()))
+            .Returns(async (string key, CancellationToken ct) =>
+            {
+                await Task.Delay(1, ct); // Simulate 1ms DB latency
+                return "test-value";
+            });
+
+        _mockInner.Setup(m => m.GetValuesAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
+            .Returns(async (IReadOnlyCollection<string> keys, CancellationToken ct) =>
+            {
+                await Task.Delay(1, ct); // Simulate 1ms DB latency
+                return keys.ToDictionary(k => k, k => "test-value");
+            });
+
+        _cachedRepo = new CachedSettingsRepository(_mockInner.Object, _memoryCache,
+            NullLogger<CachedSettingsRepository>.Instance);
+        _directRepo = _mockInner.Object;
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _memoryCache.Dispose();
+    }
+
+    [Benchmark(Baseline = true, Description = "Direct repository call (no caching)")]
+    public async Task<string?> GetValue_Direct()
+    {
+        return await _directRepo.GetValueAsync("test-key");
+    }
+
+    [Benchmark(Description = "Cached repository (warm cache - memory hit)")]
+    public async Task<string?> GetValue_Cached_Warm()
+    {
+        // First call to populate cache
+        _ = await _cachedRepo.GetValueAsync("test-key");
+        // Second call should hit cache
+        return await _cachedRepo.GetValueAsync("test-key");
+    }
+
+    [Benchmark(Description = "Cached repository (cold cache - DB call + populate)")]
+    public async Task<string?> GetValue_Cached_Cold()
+    {
+        // Clear cache before each iteration
+        _memoryCache.Remove("setting:test-key");
+        return await _cachedRepo.GetValueAsync("test-key");
+    }
+
+    [Benchmark(Description = "Batch get - 5 keys (direct)")]
+    public async Task<IReadOnlyDictionary<string, string>> GetValues_Batch_Direct()
+    {
+        var keys = new[] { "key1", "key2", "key3", "key4", "key5" };
+        return await _directRepo.GetValuesAsync(keys);
+    }
+
+    [Benchmark(Description = "Batch get - 5 keys (cached)")]
+    public async Task<IReadOnlyDictionary<string, string>> GetValues_Batch_Cached()
+    {
+        // Populate cache first
+        var keys = new[] { "key1", "key2", "key3", "key4", "key5" };
+        _ = await _cachedRepo.GetValuesAsync(keys);
+
+        // Clear one key to simulate partial cache miss
+        _memoryCache.Remove("setting:key3");
+
+        // This call should hit cache for 4 keys, DB for 1
+        return await _cachedRepo.GetValuesAsync(keys);
+    }
+}
+
+/// <summary>
+///     Benchmark untuk memory cache operations.
+/// </summary>
+[SimpleJob(RunStrategy.Throughput, 1, 3, 5)]
+[MemoryDiagnoser]
+[MarkdownExporter]
+[HtmlExporter]
+public class MemoryCacheBenchmarks
+{
+    private IMemoryCache _memoryCache = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _memoryCache = new MemoryCache(new MemoryCacheOptions());
+
+        // Pre-populate cache
+        for (var i = 0; i < 100; i++) _memoryCache.Set($"key:{i}", $"value{i}", TimeSpan.FromMinutes(5));
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _memoryCache.Dispose();
+    }
+
+    [Benchmark(Baseline = true, Description = "Cache read (hit)")]
+    public string? CacheRead_Hit()
+    {
+        return _memoryCache.TryGetValue("key:50", out string? value) ? value : null;
+    }
+
+    [Benchmark(Description = "Cache write")]
+    public void CacheWrite()
+    {
+        _memoryCache.Set($"key:{Guid.NewGuid()}", "new-value", TimeSpan.FromMinutes(5));
+    }
+
+    [Benchmark(Description = "Cache read (miss)")]
+    public bool CacheRead_Miss()
+    {
+        return _memoryCache.TryGetValue("key:nonexistent", out string? _);
+    }
+}

--- a/suryami62.Tests/Benchmarks/ImageProcessingBenchmarks.cs
+++ b/suryami62.Tests/Benchmarks/ImageProcessingBenchmarks.cs
@@ -1,0 +1,165 @@
+#region
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Formats.Webp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+#endregion
+
+namespace suryami62.Tests.Benchmarks;
+
+/// <summary>
+///     Benchmarks untuk image processing dan format comparison.
+/// </summary>
+[SimpleJob(RunStrategy.Throughput, 1, 2, 3)]
+[MemoryDiagnoser]
+[MarkdownExporter]
+[HtmlExporter]
+public class ImageProcessingBenchmarks
+{
+    private byte[] _largeImageBytes = null!;
+    private byte[] _mediumImageBytes = null!;
+    private string _outputPath = null!;
+    private byte[] _smallImageBytes = null!;
+
+    [Params(1920, 1200, 800)] public int TargetWidth { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Create test images of different sizes
+        _largeImageBytes = CreateTestImage(1920, 1080, new Rgba32(255, 0, 0)); // Red
+        _mediumImageBytes = CreateTestImage(1200, 800, new Rgba32(0, 255, 0)); // Green
+        _smallImageBytes = CreateTestImage(800, 600, new Rgba32(0, 0, 255)); // Blue
+
+        _outputPath = Path.Combine(Path.GetTempPath(), $"benchmark_output_{Guid.NewGuid()}.webp");
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        if (File.Exists(_outputPath)) File.Delete(_outputPath);
+    }
+
+    private static byte[] CreateTestImage(int width, int height, Rgba32 color)
+    {
+        using var image = new Image<Rgba32>(width, height);
+        image.Mutate(x => x.BackgroundColor(color));
+
+        // Add some visual complexity with noise-like pattern to simulate real image content
+        var random = new Random(42); // Seeded for reproducibility
+        for (var i = 0; i < 1000; i++)
+        {
+            var x = random.Next(width);
+            var y = random.Next(height);
+            var pixelColor = new Rgba32(
+                (byte)random.Next(256),
+                (byte)random.Next(256),
+                (byte)random.Next(256),
+                200);
+            image[x, y] = pixelColor;
+        }
+
+        using var ms = new MemoryStream();
+        image.Save(ms, new PngEncoder());
+        return ms.ToArray();
+    }
+
+    [Benchmark(Baseline = true, Description = "Load and resize PNG to WebP (original format)")]
+    public async Task<long> ProcessAndSave_WebP()
+    {
+        using var stream = new MemoryStream(_largeImageBytes);
+        using var image = await Image.LoadAsync(stream);
+
+        // Resize
+        image.Mutate(x => x.Resize(new ResizeOptions
+        {
+            Mode = ResizeMode.Max,
+            Size = new Size(TargetWidth, TargetWidth)
+        }));
+
+        // Save as WebP
+        await image.SaveAsync(_outputPath, new WebpEncoder { Quality = 85 });
+
+        return new FileInfo(_outputPath).Length;
+    }
+
+    [Benchmark(Description = "Load and resize PNG to JPEG")]
+    public async Task<long> ProcessAndSave_Jpeg()
+    {
+        var jpegPath = Path.ChangeExtension(_outputPath, ".jpg");
+        using var stream = new MemoryStream(_largeImageBytes);
+        using var image = await Image.LoadAsync(stream);
+
+        image.Mutate(x => x.Resize(new ResizeOptions
+        {
+            Mode = ResizeMode.Max,
+            Size = new Size(TargetWidth, TargetWidth)
+        }));
+
+        await image.SaveAsync(jpegPath, new JpegEncoder { Quality = 85 });
+
+        var size = new FileInfo(jpegPath).Length;
+        File.Delete(jpegPath);
+        return size;
+    }
+
+    [Benchmark(Description = "Load and resize PNG to PNG")]
+    public async Task<long> ProcessAndSave_Png()
+    {
+        var pngPath = Path.ChangeExtension(_outputPath, ".png");
+        using var stream = new MemoryStream(_largeImageBytes);
+        using var image = await Image.LoadAsync(stream);
+
+        image.Mutate(x => x.Resize(new ResizeOptions
+        {
+            Mode = ResizeMode.Max,
+            Size = new Size(TargetWidth, TargetWidth)
+        }));
+
+        await image.SaveAsync(pngPath, new PngEncoder());
+
+        var size = new FileInfo(pngPath).Length;
+        File.Delete(pngPath);
+        return size;
+    }
+
+    [Benchmark(Description = "Resize with Lanczos3 resampler")]
+    public async Task<long> Resize_Lanczos3()
+    {
+        using var stream = new MemoryStream(_largeImageBytes);
+        using var image = await Image.LoadAsync(stream);
+
+        image.Mutate(x => x.Resize(new ResizeOptions
+        {
+            Mode = ResizeMode.Max,
+            Size = new Size(TargetWidth, TargetWidth),
+            Sampler = KnownResamplers.Lanczos3
+        }));
+
+        await image.SaveAsync(_outputPath, new WebpEncoder { Quality = 85 });
+        return new FileInfo(_outputPath).Length;
+    }
+
+    [Benchmark(Description = "Resize with Bicubic resampler")]
+    public async Task<long> Resize_Bicubic()
+    {
+        using var stream = new MemoryStream(_largeImageBytes);
+        using var image = await Image.LoadAsync(stream);
+
+        image.Mutate(x => x.Resize(new ResizeOptions
+        {
+            Mode = ResizeMode.Max,
+            Size = new Size(TargetWidth, TargetWidth),
+            Sampler = KnownResamplers.Bicubic
+        }));
+
+        await image.SaveAsync(_outputPath, new WebpEncoder { Quality = 85 });
+        return new FileInfo(_outputPath).Length;
+    }
+}

--- a/suryami62.Tests/Program.cs
+++ b/suryami62.Tests/Program.cs
@@ -1,0 +1,34 @@
+#region
+
+using suryami62.Tests.Benchmarks;
+
+#endregion
+
+// Entry point untuk menjalankan benchmarks
+Console.WriteLine("=== suryami62 Benchmark Runner ===\n");
+
+if (args.Length == 0 || args[0] == "--all")
+{
+    Console.WriteLine("Running all benchmarks...\n");
+    BenchmarkRunner.RunAll();
+}
+else if (args[0] == "--caching")
+{
+    Console.WriteLine("Running caching benchmarks...\n");
+    BenchmarkRunner.RunCachingBenchmarks();
+}
+else if (args[0] == "--image")
+{
+    Console.WriteLine("Running image processing benchmarks...\n");
+    BenchmarkRunner.RunImageBenchmarks();
+}
+else
+{
+    Console.WriteLine("Usage:");
+    Console.WriteLine("  dotnet run -- [options]");
+    Console.WriteLine("");
+    Console.WriteLine("Options:");
+    Console.WriteLine("  --all      Run all benchmarks (default)");
+    Console.WriteLine("  --caching  Run caching benchmarks only");
+    Console.WriteLine("  --image    Run image processing benchmarks only");
+}

--- a/suryami62.Tests/suryami62.Tests.csproj
+++ b/suryami62.Tests/suryami62.Tests.csproj
@@ -5,6 +5,8 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
+        <IsTestProject>false</IsTestProject>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -13,14 +15,24 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" Version="0.14.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.4"/>
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
+        <PackageReference Include="Moq" Version="4.20.72"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4"/>
     </ItemGroup>
 
     <ItemGroup>
         <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\suryami62\suryami62.csproj"/>
+        <ProjectReference Include="..\suryami62.Application\suryami62.Application.csproj"/>
+        <ProjectReference Include="..\suryami62.Infrastructure\suryami62.Infrastructure.csproj"/>
+        <ProjectReference Include="..\suryami62.Domain\suryami62.Domain.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/suryami62/Components/Account/Pages/Admin/SeoFiles.razor
+++ b/suryami62/Components/Account/Pages/Admin/SeoFiles.razor
@@ -91,13 +91,14 @@
 
     private bool HasSuccessMessage { get; set; }
 
-    [SupplyParameterFromForm] private InputModel FormInput { get; set; } = new();
+    [SupplyParameterFromForm] private InputModel FormInput { get; set; } = null!;
 
     /// <summary>
     ///     Loads the persisted SEO settings into the form shown on the admin page.
     /// </summary>
     protected override async Task OnInitializedAsync()
     {
+        FormInput ??= new InputModel();
         await LoadFormInputAsync();
     }
 

--- a/suryami62/Services/MediaService.cs
+++ b/suryami62/Services/MediaService.cs
@@ -2,6 +2,9 @@
 
 using System.Globalization;
 using System.Text;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Webp;
+using SixLabors.ImageSharp.Processing;
 
 #endregion
 
@@ -63,11 +66,14 @@ internal sealed class MediaService(IWebHostEnvironment webHostEnvironment) : IMe
 
             var storedFileName = GetUniqueFileName(validationResult.SafeFileName!);
             var destinationPath = Path.Combine(_uploadsDirectory, storedFileName);
-            var copyResult = await SaveFileAsync(stream, destinationPath, maxAllowedSize).ConfigureAwait(false);
 
-            return copyResult.Success
+            // Process and optimize image before saving
+            var processResult = await ProcessAndSaveImageAsync(stream, destinationPath, maxAllowedSize, contentType)
+                .ConfigureAwait(false);
+
+            return processResult.Success
                 ? new UploadResult(true, $"Successfully uploaded {storedFileName}", storedFileName)
-                : new UploadResult(false, copyResult.Message);
+                : new UploadResult(false, processResult.Message);
         }
         catch (IOException)
         {
@@ -76,6 +82,10 @@ internal sealed class MediaService(IWebHostEnvironment webHostEnvironment) : IMe
         catch (UnauthorizedAccessException)
         {
             return new UploadResult(false, "An error occurred while uploading the file (Access denied).");
+        }
+        catch (InvalidOperationException ex)
+        {
+            return new UploadResult(false, $"Image processing error: {ex.Message}");
         }
     }
 
@@ -165,6 +175,72 @@ internal sealed class MediaService(IWebHostEnvironment webHostEnvironment) : IMe
         catch (UnauthorizedAccessException)
         {
             // Cleanup is best-effort; preserve the original upload failure when deletion also fails.
+        }
+    }
+
+    /// <summary>
+    ///     Processes the uploaded image by resizing if too large and converting to WebP for optimal compression.
+    /// </summary>
+    private static async Task<(bool Success, string Message)> ProcessAndSaveImageAsync(
+        Stream source,
+        string destinationPath,
+        long maxAllowedSize,
+        string contentType)
+    {
+        // Check size limit first using a memory buffer
+        using var memoryStream = new MemoryStream();
+        await source.CopyToAsync(memoryStream).ConfigureAwait(false);
+
+        if (memoryStream.Length > maxAllowedSize)
+            return (false, $"File is too large. Max allowed size is {maxAllowedSize} bytes.");
+
+        memoryStream.Position = 0;
+
+        try
+        {
+            using var image = await Image.LoadAsync(memoryStream).ConfigureAwait(false);
+
+            // Resize if image is too large (max 1920px on longest side)
+            const int maxDimension = 1920;
+            if (image.Width > maxDimension || image.Height > maxDimension)
+                image.Mutate(x => x.Resize(new ResizeOptions
+                {
+                    Mode = ResizeMode.Max,
+                    Size = new Size(maxDimension, maxDimension)
+                }));
+
+            // Auto-orient based on EXIF data
+            image.Mutate(x => x.AutoOrient());
+
+            // Determine output format based on content type
+            var extension = Path.GetExtension(destinationPath).ToUpperInvariant();
+
+            // Convert to WebP for better compression (unless already WebP)
+            string outputPath;
+            if (extension != ".WEBP")
+                outputPath = Path.ChangeExtension(destinationPath, ".webp");
+            else
+                outputPath = destinationPath;
+
+            // Save as WebP with quality 85 (good balance between quality and size)
+            var webpEncoder = new WebpEncoder
+            {
+                Quality = 85,
+                FileFormat = WebpFileFormatType.Lossy
+            };
+
+            await image.SaveAsync(outputPath, webpEncoder).ConfigureAwait(false);
+
+            // If we converted to WebP, delete the original path reference
+            if (outputPath != destinationPath && File.Exists(destinationPath)) File.Delete(destinationPath);
+
+            return (true, string.Empty);
+        }
+        catch (UnknownImageFormatException)
+        {
+            // If image processing fails, fall back to direct save
+            memoryStream.Position = 0;
+            return await SaveFileAsync(memoryStream, destinationPath, maxAllowedSize).ConfigureAwait(false);
         }
     }
 

--- a/suryami62/Services/MediaService.cs
+++ b/suryami62/Services/MediaService.cs
@@ -68,7 +68,7 @@ internal sealed class MediaService(IWebHostEnvironment webHostEnvironment) : IMe
             var destinationPath = Path.Combine(_uploadsDirectory, storedFileName);
 
             // Process and optimize image before saving
-            var processResult = await ProcessAndSaveImageAsync(stream, destinationPath, maxAllowedSize, contentType)
+            var processResult = await ProcessAndSaveImageAsync(stream, destinationPath, maxAllowedSize)
                 .ConfigureAwait(false);
 
             return processResult.Success
@@ -184,8 +184,7 @@ internal sealed class MediaService(IWebHostEnvironment webHostEnvironment) : IMe
     private static async Task<(bool Success, string Message)> ProcessAndSaveImageAsync(
         Stream source,
         string destinationPath,
-        long maxAllowedSize,
-        string contentType)
+        long maxAllowedSize)
     {
         // Check size limit first using a memory buffer
         using var memoryStream = new MemoryStream();

--- a/suryami62/Services/RedisCacheService.cs
+++ b/suryami62/Services/RedisCacheService.cs
@@ -10,7 +10,7 @@ namespace suryami62.Services;
 /// <summary>
 ///     Redis-backed distributed cache service implementation.
 /// </summary>
-internal sealed class RedisCacheService : IRedisCacheService, IDisposable
+public sealed class RedisCacheService : IRedisCacheService, IDisposable
 {
     private readonly IConnectionMultiplexer _connection;
     private readonly IDatabase _database;

--- a/suryami62/Startup/SeoEndpointRouteBuilderExtensions.cs
+++ b/suryami62/Startup/SeoEndpointRouteBuilderExtensions.cs
@@ -100,7 +100,7 @@ internal static class SeoEndpointRouteBuilderExtensions
 
     private static string BuildSitemapXml(string canonicalBaseUrl, IEnumerable<BlogPost> posts)
     {
-        var sb = new StringBuilder();
+        var sb = new StringBuilder(4096); // Pre-allocate typical capacity
         sb.AppendLine("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
         sb.AppendLine("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">");
 
@@ -138,7 +138,7 @@ internal static class SeoEndpointRouteBuilderExtensions
 
     private static string BuildRobotsText(string canonicalBaseUrl, string? disallowList)
     {
-        var sb = new StringBuilder();
+        var sb = new StringBuilder(512); // Pre-allocate typical capacity
         sb.AppendLine("User-agent: *");
         sb.AppendLine("Allow: /");
 
@@ -153,11 +153,11 @@ internal static class SeoEndpointRouteBuilderExtensions
     {
         if (string.IsNullOrWhiteSpace(disallowList)) yield break;
 
-        var lines = disallowList.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
-        foreach (var line in lines)
+        foreach (var line in disallowList.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
         {
-            var trimmedLine = line.Trim();
-            if (!string.IsNullOrWhiteSpace(trimmedLine)) yield return trimmedLine;
+            var trimmed = line.Trim();
+            if (!string.IsNullOrWhiteSpace(trimmed))
+                yield return trimmed;
         }
     }
 }

--- a/suryami62/Startup/WebApplicationExtensions.cs
+++ b/suryami62/Startup/WebApplicationExtensions.cs
@@ -15,6 +15,17 @@ namespace suryami62.Startup;
 /// </summary>
 internal static partial class WebApplicationExtensions
 {
+    // Pre-computed security headers for efficiency - avoid rebuilding on every request
+    private const string ContentSecurityPolicyValue =
+        "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; " +
+        "img-src 'self' data: https:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; " +
+        "script-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; form-action 'self'";
+
+    private const string ReferrerPolicyValue = "strict-origin-when-cross-origin";
+    private const string XContentTypeOptionsValue = "nosniff";
+    private const string XFrameOptionsValue = "DENY";
+    private const string PermissionsPolicyValue = "camera=(), microphone=(), geolocation=()";
+
     /// <summary>
     ///     Applies the middleware pipeline used by the web application.
     /// </summary>
@@ -29,8 +40,19 @@ internal static partial class WebApplicationExtensions
         app.UseForwardedHeaders();
         app.UseStatusCodePagesWithReExecute("/not-found", createScopeForStatusCodePages: true);
         app.UseHttpsRedirection();
+
+        // Add response compression early in the pipeline (before static files)
+        app.UseResponseCompression();
+
         app.UseSecurityHeaders();
         app.UseRateLimiter();
+
+        // Add response caching middleware (for static files and API responses)
+        app.UseResponseCaching();
+
+        // Add output caching middleware (for Blazor pages - better than response caching for UI)
+        app.UseOutputCache();
+
         app.UseStaticUploads();
         app.UseAntiforgery();
 
@@ -104,11 +126,11 @@ internal static partial class WebApplicationExtensions
             context.Response.OnStarting(() =>
             {
                 var headers = context.Response.Headers;
-                headers["Content-Security-Policy"] = BuildContentSecurityPolicy();
-                headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
-                headers["X-Content-Type-Options"] = "nosniff";
-                headers["X-Frame-Options"] = "DENY";
-                headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()";
+                headers["Content-Security-Policy"] = ContentSecurityPolicyValue;
+                headers["Referrer-Policy"] = ReferrerPolicyValue;
+                headers["X-Content-Type-Options"] = XContentTypeOptionsValue;
+                headers["X-Frame-Options"] = XFrameOptionsValue;
+                headers["Permissions-Policy"] = PermissionsPolicyValue;
                 return Task.CompletedTask;
             });
 
@@ -121,26 +143,19 @@ internal static partial class WebApplicationExtensions
         var uploadsPath = Path.Combine(app.Environment.WebRootPath, "img", "uploads");
         Directory.CreateDirectory(uploadsPath);
 
+        // Static files with aggressive caching (images rarely change)
         app.UseStaticFiles(new StaticFileOptions
         {
             FileProvider = new PhysicalFileProvider(uploadsPath),
-            RequestPath = "/img/uploads"
+            RequestPath = "/img/uploads",
+            OnPrepareResponse = ctx =>
+            {
+                // Cache images for 7 days - they rarely change
+                const int maxAgeSeconds = 604800; // 7 days
+                ctx.Context.Response.Headers.CacheControl =
+                    $"public,max-age={maxAgeSeconds},immutable";
+            }
         });
-    }
-
-    private static string BuildContentSecurityPolicy()
-    {
-        return string.Join("; ",
-            "default-src 'self'",
-            "base-uri 'self'",
-            "object-src 'none'",
-            "frame-ancestors 'none'",
-            "img-src 'self' data: https:",
-            "font-src 'self' data:",
-            "style-src 'self' 'unsafe-inline'",
-            "script-src 'self' 'unsafe-inline'",
-            "connect-src 'self' ws: wss:",
-            "form-action 'self'");
     }
 
     /// <summary>

--- a/suryami62/Startup/WebServiceCollectionExtensions.cs
+++ b/suryami62/Startup/WebServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 #region
 
+using System.IO.Compression;
+using System.Net;
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components;
@@ -7,6 +9,7 @@ using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;
@@ -26,6 +29,16 @@ namespace suryami62.Startup;
 /// </summary>
 internal static class WebServiceCollectionExtensions
 {
+    private static readonly SlidingWindowRateLimiterOptions AuthRateLimiterOptions = new()
+    {
+        PermitLimit = 5,
+        Window = TimeSpan.FromMinutes(1),
+        SegmentsPerWindow = 6,
+        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+        QueueLimit = 0,
+        AutoReplenishment = true
+    };
+
     /// <summary>
     ///     Adds the presentation, security, and persistence services used by the web project.
     /// </summary>
@@ -39,14 +52,14 @@ internal static class WebServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
-        AddPresentationServices(services);
+        AddPresentationServices(services, configuration);
         AddSecurityServices(services);
         AddPersistenceServices(services, configuration);
 
         return services;
     }
 
-    private static void AddPresentationServices(IServiceCollection services)
+    private static void AddPresentationServices(IServiceCollection services, IConfiguration configuration)
     {
         services.AddRazorComponents()
             .AddInteractiveServerComponents();
@@ -62,6 +75,9 @@ internal static class WebServiceCollectionExtensions
         services.AddScoped<IMediaService>(sp => new MediaService(sp.GetRequiredService<IWebHostEnvironment>()));
         services.AddScoped(_ => new MarkdownRenderer());
 
+        // Add caching services (memory + distributed + output)
+        AddCachingServices(services, configuration);
+
         // Add Redis distributed cache
         AddRedisServices(services);
     }
@@ -75,16 +91,79 @@ internal static class WebServiceCollectionExtensions
                                    throw new InvalidOperationException(
                                        "Redis connection string 'RedisConnectionString' is not configured.");
 
-            var options = ConfigurationOptions.Parse(connectionString);
+            var options = ParseRedisConnectionString(connectionString);
             options.AbortOnConnectFail = false;
-            options.ConnectTimeout = 5000;
-            options.SyncTimeout = 5000;
-            options.AsyncTimeout = 5000;
 
             return ConnectionMultiplexer.Connect(options);
         });
 
         services.AddScoped<IRedisCacheService, RedisCacheService>();
+    }
+
+    /// <summary>
+    ///     Parses a Redis connection string in the format:
+    ///     Host=[HOST];Port=[PORT];Username=[USERNAME];Password=[PASSWORD]
+    ///     into StackExchange.Redis ConfigurationOptions.
+    /// </summary>
+    private static ConfigurationOptions ParseRedisConnectionString(string connectionString)
+    {
+        var options = new ConfigurationOptions();
+        string? host = null;
+        int? port = null;
+
+        foreach (var part in connectionString.Split(';', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var keyValue = part.Split('=', 2);
+            if (keyValue.Length != 2) continue;
+
+            var key = keyValue[0].Trim().ToUpperInvariant();
+            var value = keyValue[1].Trim();
+
+            switch (key)
+            {
+                case "HOST" when !string.IsNullOrEmpty(value):
+                    host = value;
+                    break;
+                case "PORT" when int.TryParse(value, out var parsedPort):
+                    port = parsedPort;
+                    break;
+                case "USERNAME":
+                    options.User = value;
+                    break;
+                case "PASSWORD":
+                    options.Password = value;
+                    break;
+                case "DEFAULTDATABASE" when int.TryParse(value, out var db):
+                    options.DefaultDatabase = db;
+                    break;
+                case "ABORTCONNECTFAIL" or "ABORTCONNECT" when bool.TryParse(value, out var abortConnect):
+                    options.AbortOnConnectFail = abortConnect;
+                    break;
+                case "CONNECTTIMEOUT" when int.TryParse(value, out var connectTimeout):
+                    options.ConnectTimeout = connectTimeout;
+                    break;
+                case "SYNCTIMEOUT" when int.TryParse(value, out var syncTimeout):
+                    options.SyncTimeout = syncTimeout;
+                    break;
+                case "CONNECTRETRY" when int.TryParse(value, out var connectRetry):
+                    options.ConnectRetry = connectRetry;
+                    break;
+                case "ssl" or "usessl" when bool.TryParse(value, out var ssl):
+                    options.Ssl = ssl;
+                    break;
+            }
+        }
+
+        if (string.IsNullOrEmpty(host))
+            throw new InvalidOperationException(
+                "No Redis endpoint specified. Connection string must contain at least a 'Host' parameter.");
+
+        if (port.HasValue)
+            options.EndPoints.Add(new DnsEndPoint(host, port.Value));
+        else
+            options.EndPoints.Add(host);
+
+        return options;
     }
 
     private static void AddSecurityServices(IServiceCollection services)
@@ -125,11 +204,54 @@ internal static class WebServiceCollectionExtensions
 
         services.AddDbContext<ApplicationDbContext>(options =>
         {
-            options.UseNpgsql(connectionString, npgsqlOptions => { npgsqlOptions.EnableRetryOnFailure(); });
+            options.UseNpgsql(connectionString, npgsqlOptions =>
+            {
+                npgsqlOptions.EnableRetryOnFailure(3);
+                npgsqlOptions.CommandTimeout(30);
+            });
         });
 
         services.AddInfrastructureServices();
         services.AddDatabaseDeveloperPageExceptionFilter();
+    }
+
+    /// <summary>
+    ///     Adds caching services: In-Memory Cache, Output Cache, and Response Caching.
+    /// </summary>
+    private static void AddCachingServices(IServiceCollection services, IConfiguration configuration)
+    {
+        // Add memory cache for frequently accessed, rarely-changing data
+        services.AddMemoryCache();
+
+        // Add output caching for Blazor pages (better than response caching for UI apps)
+        services.AddOutputCache(options =>
+        {
+            // Base policy: 60 seconds for most content
+            options.AddBasePolicy(builder => builder.Expire(TimeSpan.FromSeconds(60)));
+
+            // Named policies for different cache durations
+            options.AddPolicy("Short", builder => builder.Expire(TimeSpan.FromSeconds(10)));
+            options.AddPolicy("Medium", builder => builder.Expire(TimeSpan.FromMinutes(5)));
+            options.AddPolicy("Long", builder => builder.Expire(TimeSpan.FromHours(1)));
+            options.AddPolicy("Static", builder => builder.Expire(TimeSpan.FromHours(24)));
+        });
+
+        // Add response caching middleware for static files and API responses
+        services.AddResponseCaching();
+
+        // Add response compression for text-based content
+        services.AddResponseCompression(options =>
+        {
+            options.EnableForHttps = true;
+            options.Providers.Add<BrotliCompressionProvider>();
+            options.Providers.Add<GzipCompressionProvider>();
+            options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(
+                ["application/javascript", "application/css", "text/css", "text/javascript", "image/svg+xml"]);
+        });
+
+        services.Configure<BrotliCompressionProviderOptions>(options => { options.Level = CompressionLevel.Optimal; });
+
+        services.Configure<GzipCompressionProviderOptions>(options => { options.Level = CompressionLevel.Optimal; });
     }
 
     private static void ConfigureForwardedHeaders(ForwardedHeadersOptions options)
@@ -156,32 +278,27 @@ internal static class WebServiceCollectionExtensions
 
     private static RateLimitPartition<string> BuildAuthenticationRateLimitPartition(HttpContext httpContext)
     {
-        if (!IsSensitiveAuthRequest(httpContext.Request)) return RateLimitPartition.GetNoLimiter("default");
+        var request = httpContext.Request;
+
+        // Inline path check to avoid method call overhead in hot path
+        if (!HttpMethods.IsPost(request.Method))
+            return RateLimitPartition.GetNoLimiter("default");
+
+        var path = request.Path.Value;
+        if (path is null)
+            return RateLimitPartition.GetNoLimiter("default");
+
+        // Fast path check using Span-based comparison
+        var pathSpan = path.AsSpan();
+        if (!pathSpan.Equals("/Account/Login", StringComparison.OrdinalIgnoreCase) &&
+            !pathSpan.Equals("/Account/Register", StringComparison.OrdinalIgnoreCase) &&
+            !pathSpan.Equals("/Account/ForgotPassword", StringComparison.OrdinalIgnoreCase) &&
+            !pathSpan.Equals("/Account/ResendEmailConfirmation", StringComparison.OrdinalIgnoreCase))
+            return RateLimitPartition.GetNoLimiter("default");
 
         var clientAddress = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
-        var partitionKey = $"{clientAddress}:{httpContext.Request.Path.Value}";
+        var partitionKey = $"{clientAddress}:{path}";
 
-        return RateLimitPartition.GetSlidingWindowLimiter(
-            partitionKey,
-            _ => new SlidingWindowRateLimiterOptions
-            {
-                PermitLimit = 5,
-                Window = TimeSpan.FromMinutes(1),
-                SegmentsPerWindow = 6,
-                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
-                QueueLimit = 0,
-                AutoReplenishment = true
-            });
-    }
-
-    private static bool IsSensitiveAuthRequest(HttpRequest request)
-    {
-        if (!HttpMethods.IsPost(request.Method)) return false;
-
-        var path = request.Path;
-        return path.Equals("/Account/Login", StringComparison.OrdinalIgnoreCase)
-               || path.Equals("/Account/Register", StringComparison.OrdinalIgnoreCase)
-               || path.Equals("/Account/ForgotPassword", StringComparison.OrdinalIgnoreCase)
-               || path.Equals("/Account/ResendEmailConfirmation", StringComparison.OrdinalIgnoreCase);
+        return RateLimitPartition.GetSlidingWindowLimiter(partitionKey, _ => AuthRateLimiterOptions);
     }
 }

--- a/suryami62/Startup/WebServiceCollectionExtensions.cs
+++ b/suryami62/Startup/WebServiceCollectionExtensions.cs
@@ -76,7 +76,7 @@ internal static class WebServiceCollectionExtensions
         services.AddScoped(_ => new MarkdownRenderer());
 
         // Add caching services (memory + distributed + output)
-        AddCachingServices(services, configuration);
+        AddCachingServices(services);
 
         // Add Redis distributed cache
         AddRedisServices(services);
@@ -218,7 +218,7 @@ internal static class WebServiceCollectionExtensions
     /// <summary>
     ///     Adds caching services: In-Memory Cache, Output Cache, and Response Caching.
     /// </summary>
-    private static void AddCachingServices(IServiceCollection services, IConfiguration configuration)
+    private static void AddCachingServices(IServiceCollection services)
     {
         // Add memory cache for frequently accessed, rarely-changing data
         services.AddMemoryCache();

--- a/suryami62/suryami62.csproj
+++ b/suryami62/suryami62.csproj
@@ -17,6 +17,7 @@
     <ItemGroup>
         <PackageReference Include="HtmlSanitizer" Version="9.0.892"/>
         <PackageReference Include="Markdig" Version="0.45.0"/>
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12"/>
         <PackageReference Include="Microsoft.AspNetCore.App.Internal.Assets" Version="10.0.2"/>
         <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.2"/>
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.2"/>


### PR DESCRIPTION
- Add Qodana configuration file pattern to the Docker ignore list.
- Disable specific code analysis diagnostics for test, benchmark, and service files by updating the editor configuration.
- Delete the dataSources.xml file.
- Delete the obsolete IDE index layout configuration file.
- Delete the default inspection profile configuration file.
- Remove the MarkdownSettings IDE configuration file.
- Delete the unused IDE misc XML that defines an empty KubernetesApiProvider component.
- Delete Rider project settings updater XML configuration.
- Delete the VCS directory mappings configuration file.
- Configure the Redis container to enforce a 25 MB memory limit with an LRU max‑memory policy.
- Add comprehensive tests for CreatePostAsync and DeletePostAsync, verifying repository delegation, return values, and proper handling of non‑existent IDs.
- Add null‑argument guard to ensure the post parameter is not null in UpdatePostAsync.
- Add null‑argument validation for the `project` parameter in `UpdateProjectAsync`.
- Add tests verifying GetPostsAsync behavior for empty and case‑sensitive search terms, pagination beyond total results, and ensuring CreateAsync correctly persists unpublished posts.
- Add tests for pagination behavior of GetProjectsAsync and for persisting RepoUrl and DemoUrl when creating a project.
- Add scoped memory‑cached Settings repository with logging and register base repositories to improve performance.
- Add CachedSettingsRepository decorator that provides in‑memory caching, cache‑hit/miss logging, and cache invalidation for settings retrieval and upsert operations.
- Introduce a BenchmarkRunner class that provides methods to execute all, caching-only, or image‑processing benchmarks with custom configuration, logging, and exporters.
- Add benchmarks for comparing CachedSettingsRepository performance against direct repository calls and measuring memory cache read/write operations.
- Add ImageProcessingBenchmarks to benchmark PNG loading, resizing, and saving to WebP, JPEG, and PNG with various resamplers.
- Add a benchmark runner console entry point with CLI options to execute all, caching, or image benchmarks.
- Convert the test project to an executable, add BenchmarkDotNet, ImageSharp and Moq packages, and reference the core solution projects.
- Initialize FormInput lazily by setting it to null‑default and creating a new instance in OnInitializedAsync if needed.
- Optimize uploaded images by resizing oversized files and converting them to WebP before saving, with size validation and processing error handling.
- Expose RedisCacheService as a public class.
- Preallocate StringBuilder capacities for sitemap and robots generation and streamline disallow‑list parsing.
- Add precomputed security header constants, enable response compression, response and output caching, and configure aggressive static file caching with direct header assignments.
- Add response compression, output and response caching, refined Redis connection parsing, enhanced PostgreSQL retry and timeout settings, and implement a sliding‑window authentication rate limiter with configurable defaults.
- Add SixLabors.ImageSharp v3.1.12 package reference.