### PR TITLE
feat: cache‑stampede protection and Redis cache

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -51,7 +51,7 @@
         image: redis:8-alpine
         container_name: suryami62_redis
         restart: unless-stopped
-        command: ["redis-server", "--maxmemory", "25mb", "--maxmemory-policy", "allkeys-lru"]
+        command: [ "redis-server", "--maxmemory", "25mb", "--maxmemory-policy", "allkeys-lru" ]
         mem_limit: 25m
         volumes:
             - suryami62-redis:/data

--- a/suryami62.Application.Tests/Services/ProjectServiceTests.cs
+++ b/suryami62.Application.Tests/Services/ProjectServiceTests.cs
@@ -16,6 +16,7 @@ public class ProjectServiceTests
 
     public ProjectServiceTests()
     {
+        // Service instantiated without caching/stampede protection for unit tests
         _service = new ProjectService(_repositoryMock.Object);
     }
 

--- a/suryami62.Application/Services/BlogPostService.cs
+++ b/suryami62.Application/Services/BlogPostService.cs
@@ -59,7 +59,14 @@ public interface IBlogPostService
 
 /// <summary>
 ///     Implements blog post operations with Redis caching support.
+///     Includes stampede protection to prevent multiple concurrent requests
+///     from executing the same expensive operation when cache expires.
 /// </summary>
+/// <remarks>
+///     Cache-aside pattern with stampede protection ensures optimal performance
+///     during high traffic scenarios when cache entries expire.
+///     See: https://learn.microsoft.com/aspnet/core/performance/caching/overview?view=aspnetcore-10.0#hybridcache
+/// </remarks>
 public sealed class BlogPostService : IBlogPostService
 {
     private const string CacheKeyPrefix = "blogposts:";
@@ -67,11 +74,16 @@ public sealed class BlogPostService : IBlogPostService
     private readonly IRedisCacheService? _cacheService;
 
     private readonly IBlogPostRepository _repository;
+    private readonly CacheStampedeProtection? _stampedeProtection;
 
-    public BlogPostService(IBlogPostRepository repository, IRedisCacheService? cacheService = null)
+    public BlogPostService(
+        IBlogPostRepository repository,
+        IRedisCacheService? cacheService = null,
+        CacheStampedeProtection? stampedeProtection = null)
     {
         _repository = repository;
         _cacheService = cacheService;
+        _stampedeProtection = stampedeProtection;
     }
 
     /// <inheritdoc />
@@ -91,15 +103,41 @@ public sealed class BlogPostService : IBlogPostService
             if (cached != null) return (cached.Items, cached.Total);
         }
 
-        // Cache miss - fetch from database
-        var result = await _repository.GetPostsAsync(onlyPublished, skip, take, searchTerm).ConfigureAwait(false);
+        // Cache miss - fetch from database with stampede protection
+        // This prevents multiple concurrent requests from executing the same expensive operation
+        if (_stampedeProtection != null && _cacheService != null)
+        {
+            var result = await _stampedeProtection.ExecuteAsync(cacheKey, async () =>
+            {
+                // Double-check cache after acquiring lock (another thread might have populated it)
+                var doubleCheck = await _cacheService.GetAsync<CachedBlogPostList>(cacheKey).ConfigureAwait(false);
+                if (doubleCheck != null) return (doubleCheck.Items, doubleCheck.Total);
 
-        // Store in cache
+                // Fetch from database
+                var dbResult = await _repository.GetPostsAsync(onlyPublished, skip, take, searchTerm)
+                    .ConfigureAwait(false);
+
+                // Store in cache
+                await _cacheService.SetAsync(cacheKey, new CachedBlogPostList(dbResult.Items, dbResult.Total),
+                        CacheExpiration)
+                    .ConfigureAwait(false);
+
+                return dbResult;
+            }).ConfigureAwait(false);
+
+            return result;
+        }
+
+        // Fallback without stampede protection (when not configured)
+        var fallbackResult =
+            await _repository.GetPostsAsync(onlyPublished, skip, take, searchTerm).ConfigureAwait(false);
+
         if (_cacheService != null)
-            await _cacheService.SetAsync(cacheKey, new CachedBlogPostList(result.Items, result.Total), CacheExpiration)
+            await _cacheService.SetAsync(cacheKey, new CachedBlogPostList(fallbackResult.Items, fallbackResult.Total),
+                    CacheExpiration)
                 .ConfigureAwait(false);
 
-        return result;
+        return fallbackResult;
     }
 
     /// <inheritdoc />
@@ -169,8 +207,8 @@ public sealed class BlogPostService : IBlogPostService
         // Invalidate related caches
         if (_cacheService != null)
         {
-            await _cacheService.RemoveAsync($"{CacheKeyPrefix}slug:{post.Slug}").ConfigureAwait(false);
-            await _cacheService.RemoveAsync($"{CacheKeyPrefix}id:{post.Id}").ConfigureAwait(false);
+            await _cacheService.RemoveEntryAsync($"{CacheKeyPrefix}slug:{post.Slug}").ConfigureAwait(false);
+            await _cacheService.RemoveEntryAsync($"{CacheKeyPrefix}id:{post.Id}").ConfigureAwait(false);
             await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}list:*").ConfigureAwait(false);
         }
     }
@@ -187,8 +225,8 @@ public sealed class BlogPostService : IBlogPostService
         if (_cacheService != null)
         {
             if (post != null)
-                await _cacheService.RemoveAsync($"{CacheKeyPrefix}slug:{post.Slug}").ConfigureAwait(false);
-            await _cacheService.RemoveAsync($"{CacheKeyPrefix}id:{id}").ConfigureAwait(false);
+                await _cacheService.RemoveEntryAsync($"{CacheKeyPrefix}slug:{post.Slug}").ConfigureAwait(false);
+            await _cacheService.RemoveEntryAsync($"{CacheKeyPrefix}id:{id}").ConfigureAwait(false);
             await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}list:*").ConfigureAwait(false);
         }
     }

--- a/suryami62.Application/Services/CacheStampedeProtection.cs
+++ b/suryami62.Application/Services/CacheStampedeProtection.cs
@@ -1,0 +1,81 @@
+#region
+
+using System.Collections.Concurrent;
+
+#endregion
+
+namespace suryami62.Services;
+
+/// <summary>
+///     Provides stampede protection for cache operations to prevent multiple concurrent
+///     requests from executing the same expensive operation when cache expires.
+/// </summary>
+/// <remarks>
+///     Stampede protection (a.k.a. thundering herd protection) ensures that when a cache entry
+///     expires, only one request fetches the data from the source while others wait for the result.
+///     This prevents overwhelming the database/backend with duplicate queries during high traffic.
+///     See: https://learn.microsoft.com/aspnet/core/performance/caching/overview?view=aspnetcore-10.0#hybridcache
+/// </remarks>
+public sealed class CacheStampedeProtection : IDisposable
+{
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
+    private bool _disposed;
+
+    /// <summary>
+    ///     Disposes all semaphores and clears the dictionary.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed) return;
+
+        _disposed = true;
+
+        foreach (var semaphore in _locks.Values) semaphore.Dispose();
+
+        _locks.Clear();
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    ///     Gets or creates a semaphore for the specified cache key.
+    /// </summary>
+    /// <param name="key">The cache key to lock on.</param>
+    /// <returns>A semaphore to control concurrent access.</returns>
+    public SemaphoreSlim GetLock(string key)
+    {
+        return _locks.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
+    }
+
+    /// <summary>
+    ///     Removes the lock for the specified key to prevent memory leaks.
+    /// </summary>
+    /// <param name="key">The cache key.</param>
+    public void ReleaseLock(string key)
+    {
+        if (_locks.TryRemove(key, out var semaphore)) semaphore.Dispose();
+    }
+
+    /// <summary>
+    ///     Executes the factory function with stampede protection.
+    ///     Only one concurrent execution per key is allowed.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to return.</typeparam>
+    /// <param name="key">The cache key to protect.</param>
+    /// <param name="factory">The factory function to execute.</param>
+    /// <returns>The result of the factory function.</returns>
+    public async Task<T> ExecuteAsync<T>(string key, Func<Task<T>> factory)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        var semaphore = GetLock(key);
+
+        await semaphore.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            return await factory().ConfigureAwait(false);
+        }
+        finally
+        {
+            semaphore.Release();
+        }
+    }
+}

--- a/suryami62.Application/Services/IRedisCacheService.cs
+++ b/suryami62.Application/Services/IRedisCacheService.cs
@@ -28,11 +28,11 @@ public interface IRedisCacheService
         where T : class;
 
     /// <summary>
-    ///     Removes a value from the cache.
+    ///     Removes a value from the cache by key.
     /// </summary>
     /// <param name="key">The cache key.</param>
     /// <param name="cancellationToken">The token to cancel the operation.</param>
-    Task RemoveAsync(string key, CancellationToken cancellationToken = default);
+    Task RemoveEntryAsync(string key, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Removes multiple values from the cache by pattern.

--- a/suryami62.Application/Services/JourneyHistoryService.cs
+++ b/suryami62.Application/Services/JourneyHistoryService.cs
@@ -35,7 +35,14 @@ public interface IJourneyHistoryService
 
 /// <summary>
 ///     Implements journey item operations with Redis caching support.
+///     Includes stampede protection to prevent multiple concurrent requests
+///     from executing the same expensive operation when cache expires.
 /// </summary>
+/// <remarks>
+///     Cache-aside pattern with stampede protection ensures optimal performance
+///     during high traffic scenarios when cache entries expire.
+///     See: https://learn.microsoft.com/aspnet/core/performance/caching/overview?view=aspnetcore-10.0#hybridcache
+/// </remarks>
 public sealed class JourneyHistoryService : IJourneyHistoryService
 {
     private const string CacheKeyPrefix = "journey:";
@@ -43,11 +50,16 @@ public sealed class JourneyHistoryService : IJourneyHistoryService
     private readonly IRedisCacheService? _cacheService;
 
     private readonly IJourneyHistoryRepository _repository;
+    private readonly CacheStampedeProtection? _stampedeProtection;
 
-    public JourneyHistoryService(IJourneyHistoryRepository repository, IRedisCacheService? cacheService = null)
+    public JourneyHistoryService(
+        IJourneyHistoryRepository repository,
+        IRedisCacheService? cacheService = null,
+        CacheStampedeProtection? stampedeProtection = null)
     {
         _repository = repository;
         _cacheService = cacheService;
+        _stampedeProtection = stampedeProtection;
     }
 
     /// <inheritdoc />
@@ -55,20 +67,38 @@ public sealed class JourneyHistoryService : IJourneyHistoryService
     {
         var cacheKey = $"{CacheKeyPrefix}section:{section}";
 
-        // Try to get from cache first
+        // Try to get from cache first (cache-aside pattern)
         if (_cacheService != null)
         {
             var cached = await _cacheService.GetAsync<List<JourneyHistory>>(cacheKey).ConfigureAwait(false);
             if (cached != null) return cached;
         }
 
-        // Cache miss - fetch from database
-        var items = await _repository.GetBySectionAsync(section).ConfigureAwait(false);
+        // Cache miss - fetch from database with stampede protection
+        // This prevents multiple concurrent requests from executing the same expensive operation
+        if (_stampedeProtection != null && _cacheService != null)
+            return await _stampedeProtection.ExecuteAsync(cacheKey, async () =>
+            {
+                // Double-check cache after acquiring lock (another thread might have populated it)
+                var doubleCheck = await _cacheService.GetAsync<List<JourneyHistory>>(cacheKey).ConfigureAwait(false);
+                if (doubleCheck != null) return doubleCheck;
 
-        // Store in cache
-        if (_cacheService != null) await _cacheService.SetAsync(cacheKey, items, CacheExpiration).ConfigureAwait(false);
+                // Fetch from database
+                var items = await _repository.GetBySectionAsync(section).ConfigureAwait(false);
 
-        return items;
+                // Store in cache
+                await _cacheService.SetAsync(cacheKey, items, CacheExpiration).ConfigureAwait(false);
+
+                return items;
+            }).ConfigureAwait(false);
+
+        // Fallback without stampede protection (when not configured)
+        var fallbackItems = await _repository.GetBySectionAsync(section).ConfigureAwait(false);
+
+        if (_cacheService != null)
+            await _cacheService.SetAsync(cacheKey, fallbackItems, CacheExpiration).ConfigureAwait(false);
+
+        return fallbackItems;
     }
 
     /// <inheritdoc />

--- a/suryami62.Application/Services/ProjectService.cs
+++ b/suryami62.Application/Services/ProjectService.cs
@@ -49,7 +49,14 @@ public interface IProjectService
 
 /// <summary>
 ///     Implements project operations with Redis caching support.
+///     Includes stampede protection to prevent multiple concurrent requests
+///     from executing the same expensive operation when cache expires.
 /// </summary>
+/// <remarks>
+///     Cache-aside pattern with stampede protection ensures optimal performance
+///     during high traffic scenarios when cache entries expire.
+///     See: https://learn.microsoft.com/aspnet/core/performance/caching/overview?view=aspnetcore-10.0#hybridcache
+/// </remarks>
 public sealed class ProjectService : IProjectService
 {
     private const string CacheKeyPrefix = "projects:";
@@ -57,11 +64,16 @@ public sealed class ProjectService : IProjectService
     private readonly IRedisCacheService? _cacheService;
 
     private readonly IProjectRepository _repository;
+    private readonly CacheStampedeProtection? _stampedeProtection;
 
-    public ProjectService(IProjectRepository repository, IRedisCacheService? cacheService = null)
+    public ProjectService(
+        IProjectRepository repository,
+        IRedisCacheService? cacheService = null,
+        CacheStampedeProtection? stampedeProtection = null)
     {
         _repository = repository;
         _cacheService = cacheService;
+        _stampedeProtection = stampedeProtection;
     }
 
     /// <inheritdoc />
@@ -77,15 +89,39 @@ public sealed class ProjectService : IProjectService
             if (cached != null) return (cached.Items, cached.Total);
         }
 
-        // Cache miss - fetch from database
-        var result = await _repository.GetProjectsAsync(skip, take).ConfigureAwait(false);
+        // Cache miss - fetch from database with stampede protection
+        // This prevents multiple concurrent requests from executing the same expensive operation
+        if (_stampedeProtection != null && _cacheService != null)
+        {
+            var result = await _stampedeProtection.ExecuteAsync(cacheKey, async () =>
+            {
+                // Double-check cache after acquiring lock (another thread might have populated it)
+                var doubleCheck = await _cacheService.GetAsync<CachedProjectList>(cacheKey).ConfigureAwait(false);
+                if (doubleCheck != null) return (doubleCheck.Items, doubleCheck.Total);
 
-        // Store in cache
+                // Fetch from database
+                var dbResult = await _repository.GetProjectsAsync(skip, take).ConfigureAwait(false);
+
+                // Store in cache
+                await _cacheService.SetAsync(cacheKey, new CachedProjectList(dbResult.Items, dbResult.Total),
+                        CacheExpiration)
+                    .ConfigureAwait(false);
+
+                return dbResult;
+            }).ConfigureAwait(false);
+
+            return result;
+        }
+
+        // Fallback without stampede protection (when not configured)
+        var fallbackResult = await _repository.GetProjectsAsync(skip, take).ConfigureAwait(false);
+
         if (_cacheService != null)
-            await _cacheService.SetAsync(cacheKey, new CachedProjectList(result.Items, result.Total), CacheExpiration)
+            await _cacheService.SetAsync(cacheKey, new CachedProjectList(fallbackResult.Items, fallbackResult.Total),
+                    CacheExpiration)
                 .ConfigureAwait(false);
 
-        return result;
+        return fallbackResult;
     }
 
     /// <inheritdoc />
@@ -100,14 +136,31 @@ public sealed class ProjectService : IProjectService
             if (cached != null) return cached;
         }
 
-        // Cache miss - fetch from database
-        var project = await _repository.GetByIdAsync(id).ConfigureAwait(false);
+        // Cache miss - fetch from database with stampede protection
+        if (_stampedeProtection != null && _cacheService != null)
+            return await _stampedeProtection.ExecuteAsync(cacheKey, async () =>
+            {
+                // Double-check cache after acquiring lock
+                var doubleCheck = await _cacheService.GetAsync<Project>(cacheKey).ConfigureAwait(false);
+                if (doubleCheck != null) return doubleCheck;
 
-        // Store in cache if found
-        if (_cacheService != null && project != null)
-            await _cacheService.SetAsync(cacheKey, project, CacheExpiration).ConfigureAwait(false);
+                // Fetch from database
+                var project = await _repository.GetByIdAsync(id).ConfigureAwait(false);
 
-        return project;
+                // Store in cache if found
+                if (project != null)
+                    await _cacheService.SetAsync(cacheKey, project, CacheExpiration).ConfigureAwait(false);
+
+                return project;
+            }).ConfigureAwait(false);
+
+        // Fallback without stampede protection (when not configured)
+        var fallbackProject = await _repository.GetByIdAsync(id).ConfigureAwait(false);
+
+        if (_cacheService != null && fallbackProject != null)
+            await _cacheService.SetAsync(cacheKey, fallbackProject, CacheExpiration).ConfigureAwait(false);
+
+        return fallbackProject;
     }
 
     /// <inheritdoc />
@@ -131,7 +184,7 @@ public sealed class ProjectService : IProjectService
         // Invalidate related caches
         if (_cacheService != null)
         {
-            await _cacheService.RemoveAsync($"{CacheKeyPrefix}id:{project.Id}").ConfigureAwait(false);
+            await _cacheService.RemoveEntryAsync($"{CacheKeyPrefix}id:{project.Id}").ConfigureAwait(false);
             await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}list:*").ConfigureAwait(false);
         }
     }
@@ -144,7 +197,7 @@ public sealed class ProjectService : IProjectService
         // Invalidate caches
         if (_cacheService != null)
         {
-            await _cacheService.RemoveAsync($"{CacheKeyPrefix}id:{id}").ConfigureAwait(false);
+            await _cacheService.RemoveEntryAsync($"{CacheKeyPrefix}id:{id}").ConfigureAwait(false);
             await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}list:*").ConfigureAwait(false);
         }
     }

--- a/suryami62.Application/Services/SiteProfileSettingsStore.cs
+++ b/suryami62.Application/Services/SiteProfileSettingsStore.cs
@@ -77,6 +77,7 @@ public interface ISiteProfileSettingsStore
 /// <remarks>
 ///     This store centralizes the public social and contact links rendered across the site's marketing surfaces
 ///     and edited from the admin profile settings page.
+///     Includes stampede protection for consistent high-load performance across all services.
 /// </remarks>
 public sealed class SiteProfileSettingsStore : ISiteProfileSettingsStore
 {
@@ -94,17 +95,22 @@ public sealed class SiteProfileSettingsStore : ISiteProfileSettingsStore
     private readonly IRedisCacheService? _cacheService;
 
     private readonly ISettingsRepository _repository;
+    private readonly CacheStampedeProtection? _stampedeProtection;
 
-    public SiteProfileSettingsStore(ISettingsRepository repository, IRedisCacheService? cacheService = null)
+    public SiteProfileSettingsStore(
+        ISettingsRepository repository,
+        IRedisCacheService? cacheService = null,
+        CacheStampedeProtection? stampedeProtection = null)
     {
         _repository = repository;
         _cacheService = cacheService;
+        _stampedeProtection = stampedeProtection;
     }
 
     /// <inheritdoc />
     public async Task<SiteProfileSettings> GetAsync(CancellationToken cancellationToken = default)
     {
-        // Try to get from cache first
+        // Try to get from cache first (cache-aside pattern)
         if (_cacheService != null)
         {
             var cached = await _cacheService.GetAsync<SiteProfileSettings>(CacheKey, cancellationToken)
@@ -112,15 +118,36 @@ public sealed class SiteProfileSettingsStore : ISiteProfileSettingsStore
             if (cached != null) return cached;
         }
 
-        // Cache miss - load from repository
-        var storedValues = await LoadStoredValuesAsync(cancellationToken).ConfigureAwait(false);
-        var settings = CreateSettings(storedValues);
+        // Cache miss - load from repository with stampede protection
+        // This prevents multiple concurrent requests from executing the same expensive operation
+        if (_stampedeProtection != null && _cacheService != null)
+            return await _stampedeProtection.ExecuteAsync(CacheKey, async () =>
+            {
+                // Double-check cache after acquiring lock (another thread might have populated it)
+                var doubleCheck = await _cacheService.GetAsync<SiteProfileSettings>(CacheKey, cancellationToken)
+                    .ConfigureAwait(false);
+                if (doubleCheck != null) return doubleCheck;
 
-        // Store in cache
+                // Fetch from repository
+                var storedValues = await LoadStoredValuesAsync(cancellationToken).ConfigureAwait(false);
+                var settings = CreateSettings(storedValues);
+
+                // Store in cache
+                await _cacheService.SetAsync(CacheKey, settings, CacheExpiration, cancellationToken)
+                    .ConfigureAwait(false);
+
+                return settings;
+            }).ConfigureAwait(false);
+
+        // Fallback without stampede protection (when not configured)
+        var fallbackStoredValues = await LoadStoredValuesAsync(cancellationToken).ConfigureAwait(false);
+        var fallbackSettings = CreateSettings(fallbackStoredValues);
+
         if (_cacheService != null)
-            await _cacheService.SetAsync(CacheKey, settings, CacheExpiration, cancellationToken).ConfigureAwait(false);
+            await _cacheService.SetAsync(CacheKey, fallbackSettings, CacheExpiration, cancellationToken)
+                .ConfigureAwait(false);
 
-        return settings;
+        return fallbackSettings;
     }
 
     /// <inheritdoc />
@@ -131,7 +158,8 @@ public sealed class SiteProfileSettingsStore : ISiteProfileSettingsStore
         await _repository.UpsertManyAsync(CreatePersistedValues(settings), cancellationToken).ConfigureAwait(false);
 
         // Invalidate cache
-        if (_cacheService != null) await _cacheService.RemoveAsync(CacheKey, cancellationToken).ConfigureAwait(false);
+        if (_cacheService != null)
+            await _cacheService.RemoveEntryAsync(CacheKey, cancellationToken).ConfigureAwait(false);
     }
 
     private Task<IReadOnlyDictionary<string, string>> LoadStoredValuesAsync(CancellationToken cancellationToken)

--- a/suryami62.Infrastructure/Persistence/CachedSettingsRepository.cs
+++ b/suryami62.Infrastructure/Persistence/CachedSettingsRepository.cs
@@ -153,6 +153,7 @@ public sealed partial class CachedSettingsRepository : ISettingsRepository
     [LoggerMessage(Level = LogLevel.Debug, Message = "Cache INVALIDATED for setting '{SettingKey}'")]
     private partial void LogCacheInvalidated(string settingKey);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "CachedSettingsRepository initialized with cache duration: {CacheDuration}")]
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "CachedSettingsRepository initialized with cache duration: {CacheDuration}")]
     private partial void LogRepositoryInitialized(TimeSpan cacheDuration);
 }

--- a/suryami62.Tests/Benchmarks/CachingBenchmarks.cs
+++ b/suryami62.Tests/Benchmarks/CachingBenchmarks.cs
@@ -19,12 +19,18 @@ namespace suryami62.Tests.Benchmarks;
 [MemoryDiagnoser]
 [MarkdownExporter]
 [HtmlExporter]
-public class CachingBenchmarks
+public sealed class CachingBenchmarks : IDisposable
 {
     private CachedSettingsRepository _cachedRepo = null!;
     private ISettingsRepository _directRepo = null!;
-    private IMemoryCache _memoryCache = null!;
+    private MemoryCache _memoryCache = null!;
     private Mock<ISettingsRepository> _mockInner = null!;
+
+    public void Dispose()
+    {
+        _memoryCache?.Dispose();
+        GC.SuppressFinalize(this);
+    }
 
     [GlobalSetup]
     public void Setup()
@@ -36,14 +42,14 @@ public class CachingBenchmarks
         _mockInner.Setup(m => m.GetValueAsync("test-key", It.IsAny<CancellationToken>()))
             .Returns(async (string key, CancellationToken ct) =>
             {
-                await Task.Delay(1, ct); // Simulate 1ms DB latency
+                await Task.Delay(1, ct).ConfigureAwait(false); // Simulate 1ms DB latency
                 return "test-value";
             });
 
         _mockInner.Setup(m => m.GetValuesAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
             .Returns(async (IReadOnlyCollection<string> keys, CancellationToken ct) =>
             {
-                await Task.Delay(1, ct); // Simulate 1ms DB latency
+                await Task.Delay(1, ct).ConfigureAwait(false); // Simulate 1ms DB latency
                 return keys.ToDictionary(k => k, k => "test-value");
             });
 
@@ -55,22 +61,22 @@ public class CachingBenchmarks
     [GlobalCleanup]
     public void Cleanup()
     {
-        _memoryCache.Dispose();
+        _memoryCache?.Dispose();
     }
 
     [Benchmark(Baseline = true, Description = "Direct repository call (no caching)")]
     public async Task<string?> GetValue_Direct()
     {
-        return await _directRepo.GetValueAsync("test-key");
+        return await _directRepo.GetValueAsync("test-key").ConfigureAwait(false);
     }
 
     [Benchmark(Description = "Cached repository (warm cache - memory hit)")]
     public async Task<string?> GetValue_Cached_Warm()
     {
         // First call to populate cache
-        _ = await _cachedRepo.GetValueAsync("test-key");
+        _ = await _cachedRepo.GetValueAsync("test-key").ConfigureAwait(false);
         // Second call should hit cache
-        return await _cachedRepo.GetValueAsync("test-key");
+        return await _cachedRepo.GetValueAsync("test-key").ConfigureAwait(false);
     }
 
     [Benchmark(Description = "Cached repository (cold cache - DB call + populate)")]
@@ -78,14 +84,14 @@ public class CachingBenchmarks
     {
         // Clear cache before each iteration
         _memoryCache.Remove("setting:test-key");
-        return await _cachedRepo.GetValueAsync("test-key");
+        return await _cachedRepo.GetValueAsync("test-key").ConfigureAwait(false);
     }
 
     [Benchmark(Description = "Batch get - 5 keys (direct)")]
     public async Task<IReadOnlyDictionary<string, string>> GetValues_Batch_Direct()
     {
         var keys = new[] { "key1", "key2", "key3", "key4", "key5" };
-        return await _directRepo.GetValuesAsync(keys);
+        return await _directRepo.GetValuesAsync(keys).ConfigureAwait(false);
     }
 
     [Benchmark(Description = "Batch get - 5 keys (cached)")]
@@ -93,13 +99,13 @@ public class CachingBenchmarks
     {
         // Populate cache first
         var keys = new[] { "key1", "key2", "key3", "key4", "key5" };
-        _ = await _cachedRepo.GetValuesAsync(keys);
+        _ = await _cachedRepo.GetValuesAsync(keys).ConfigureAwait(false);
 
         // Clear one key to simulate partial cache miss
         _memoryCache.Remove("setting:key3");
 
         // This call should hit cache for 4 keys, DB for 1
-        return await _cachedRepo.GetValuesAsync(keys);
+        return await _cachedRepo.GetValuesAsync(keys).ConfigureAwait(false);
     }
 }
 
@@ -110,9 +116,15 @@ public class CachingBenchmarks
 [MemoryDiagnoser]
 [MarkdownExporter]
 [HtmlExporter]
-public class MemoryCacheBenchmarks
+public sealed class MemoryCacheBenchmarks : IDisposable
 {
-    private IMemoryCache _memoryCache = null!;
+    private MemoryCache _memoryCache = null!;
+
+    public void Dispose()
+    {
+        _memoryCache?.Dispose();
+        GC.SuppressFinalize(this);
+    }
 
     [GlobalSetup]
     public void Setup()
@@ -126,7 +138,7 @@ public class MemoryCacheBenchmarks
     [GlobalCleanup]
     public void Cleanup()
     {
-        _memoryCache.Dispose();
+        _memoryCache?.Dispose();
     }
 
     [Benchmark(Baseline = true, Description = "Cache read (hit)")]

--- a/suryami62.Tests/Benchmarks/ImageProcessingBenchmarks.cs
+++ b/suryami62.Tests/Benchmarks/ImageProcessingBenchmarks.cs
@@ -74,7 +74,7 @@ public class ImageProcessingBenchmarks
     public async Task<long> ProcessAndSave_WebP()
     {
         using var stream = new MemoryStream(_largeImageBytes);
-        using var image = await Image.LoadAsync(stream);
+        using var image = await Image.LoadAsync(stream).ConfigureAwait(false);
 
         // Resize
         image.Mutate(x => x.Resize(new ResizeOptions
@@ -84,7 +84,7 @@ public class ImageProcessingBenchmarks
         }));
 
         // Save as WebP
-        await image.SaveAsync(_outputPath, new WebpEncoder { Quality = 85 });
+        await image.SaveAsync(_outputPath, new WebpEncoder { Quality = 85 }).ConfigureAwait(false);
 
         return new FileInfo(_outputPath).Length;
     }
@@ -94,7 +94,7 @@ public class ImageProcessingBenchmarks
     {
         var jpegPath = Path.ChangeExtension(_outputPath, ".jpg");
         using var stream = new MemoryStream(_largeImageBytes);
-        using var image = await Image.LoadAsync(stream);
+        using var image = await Image.LoadAsync(stream).ConfigureAwait(false);
 
         image.Mutate(x => x.Resize(new ResizeOptions
         {
@@ -102,7 +102,7 @@ public class ImageProcessingBenchmarks
             Size = new Size(TargetWidth, TargetWidth)
         }));
 
-        await image.SaveAsync(jpegPath, new JpegEncoder { Quality = 85 });
+        await image.SaveAsync(jpegPath, new JpegEncoder { Quality = 85 }).ConfigureAwait(false);
 
         var size = new FileInfo(jpegPath).Length;
         File.Delete(jpegPath);
@@ -114,7 +114,7 @@ public class ImageProcessingBenchmarks
     {
         var pngPath = Path.ChangeExtension(_outputPath, ".png");
         using var stream = new MemoryStream(_largeImageBytes);
-        using var image = await Image.LoadAsync(stream);
+        using var image = await Image.LoadAsync(stream).ConfigureAwait(false);
 
         image.Mutate(x => x.Resize(new ResizeOptions
         {
@@ -122,7 +122,7 @@ public class ImageProcessingBenchmarks
             Size = new Size(TargetWidth, TargetWidth)
         }));
 
-        await image.SaveAsync(pngPath, new PngEncoder());
+        await image.SaveAsync(pngPath, new PngEncoder()).ConfigureAwait(false);
 
         var size = new FileInfo(pngPath).Length;
         File.Delete(pngPath);
@@ -133,7 +133,7 @@ public class ImageProcessingBenchmarks
     public async Task<long> Resize_Lanczos3()
     {
         using var stream = new MemoryStream(_largeImageBytes);
-        using var image = await Image.LoadAsync(stream);
+        using var image = await Image.LoadAsync(stream).ConfigureAwait(false);
 
         image.Mutate(x => x.Resize(new ResizeOptions
         {
@@ -142,7 +142,7 @@ public class ImageProcessingBenchmarks
             Sampler = KnownResamplers.Lanczos3
         }));
 
-        await image.SaveAsync(_outputPath, new WebpEncoder { Quality = 85 });
+        await image.SaveAsync(_outputPath, new WebpEncoder { Quality = 85 }).ConfigureAwait(false);
         return new FileInfo(_outputPath).Length;
     }
 
@@ -150,7 +150,7 @@ public class ImageProcessingBenchmarks
     public async Task<long> Resize_Bicubic()
     {
         using var stream = new MemoryStream(_largeImageBytes);
-        using var image = await Image.LoadAsync(stream);
+        using var image = await Image.LoadAsync(stream).ConfigureAwait(false);
 
         image.Mutate(x => x.Resize(new ResizeOptions
         {
@@ -159,7 +159,7 @@ public class ImageProcessingBenchmarks
             Sampler = KnownResamplers.Bicubic
         }));
 
-        await image.SaveAsync(_outputPath, new WebpEncoder { Quality = 85 });
+        await image.SaveAsync(_outputPath, new WebpEncoder { Quality = 85 }).ConfigureAwait(false);
         return new FileInfo(_outputPath).Length;
     }
 }

--- a/suryami62/Components/Pages/About.razor
+++ b/suryami62/Components/Pages/About.razor
@@ -1,6 +1,7 @@
 ﻿@* Public about page that presents the profile summary, roles, and journey timeline. *@
 @page "/about"
 @using suryami62.Domain.Models
+@rendermode InteractiveServer
 @inject NavigationManager NavigationManager
 @inject IJourneyHistoryService JourneyHistoryService
 @inject MarkdownRenderer MarkdownRenderer

--- a/suryami62/Services/RedisCacheService.cs
+++ b/suryami62/Services/RedisCacheService.cs
@@ -1,6 +1,7 @@
 #region
 
 using System.Text.Json;
+using Microsoft.Extensions.Caching.Distributed;
 using StackExchange.Redis;
 
 #endregion
@@ -9,13 +10,19 @@ namespace suryami62.Services;
 
 /// <summary>
 ///     Redis-backed distributed cache service implementation.
+///     Implements both IRedisCacheService (for advanced Redis operations) and IDistributedCache (for ASP.NET Core
+///     compatibility).
 /// </summary>
-public sealed class RedisCacheService : IRedisCacheService, IDisposable
+/// <remarks>
+///     IMPORTANT: IConnectionMultiplexer is registered as Singleton and managed by DI container.
+///     This service does NOT dispose the ConnectionMultiplexer as it's shared across the application lifetime.
+///     See: https://learn.microsoft.com/azure/redis/best-practices-connection#using-forcereconnect-with-stackexchangeredis
+/// </remarks>
+public sealed class RedisCacheService : IRedisCacheService, IDistributedCache
 {
     private readonly IConnectionMultiplexer _connection;
     private readonly IDatabase _database;
     private readonly JsonSerializerOptions _jsonOptions;
-    private bool _disposed;
 
     public RedisCacheService(IConnectionMultiplexer connection)
     {
@@ -29,17 +36,12 @@ public sealed class RedisCacheService : IRedisCacheService, IDisposable
         };
     }
 
-    public void Dispose()
-    {
-        if (_disposed) return;
-
-        _disposed = true;
-        GC.SuppressFinalize(this);
-    }
+    #region IRedisCacheService Implementation
 
     /// <inheritdoc />
     public async Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default) where T : class
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var value = await _database.StringGetAsync(key).ConfigureAwait(false);
 
         if (value.IsNullOrEmpty) return null;
@@ -53,6 +55,7 @@ public sealed class RedisCacheService : IRedisCacheService, IDisposable
         CancellationToken cancellationToken = default)
         where T : class
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var serialized = JsonSerializer.Serialize(value, _jsonOptions);
         var expiry = expiration ?? TimeSpan.FromMinutes(30);
 
@@ -60,19 +63,104 @@ public sealed class RedisCacheService : IRedisCacheService, IDisposable
     }
 
     /// <inheritdoc />
-    public async Task RemoveAsync(string key, CancellationToken cancellationToken = default)
-    {
-        await _database.KeyDeleteAsync(key).ConfigureAwait(false);
-    }
-
-    /// <inheritdoc />
     public async Task RemoveByPatternAsync(string pattern, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var server = _connection.GetServer(_connection.GetEndPoints()[0]);
         var keyList = new List<RedisKey>();
 
-        await foreach (var key in server.KeysAsync(pattern: pattern).ConfigureAwait(false)) keyList.Add(key);
+        await foreach (var key in server.KeysAsync(pattern: pattern).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            keyList.Add(key);
+        }
 
-        await _database.KeyDeleteAsync(keyList.ToArray()).ConfigureAwait(false);
+        if (keyList.Count > 0)
+            await _database.KeyDeleteAsync(keyList.ToArray()).ConfigureAwait(false);
     }
+
+    /// <inheritdoc cref="IRedisCacheService.RemoveEntryAsync" />
+    public async Task RemoveEntryAsync(string key, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await _database.KeyDeleteAsync(key).ConfigureAwait(false);
+    }
+
+    #endregion
+
+    #region IDistributedCache Implementation
+
+    /// <inheritdoc />
+    public byte[]? Get(string key)
+    {
+        var value = _database.StringGet(key);
+        return value.IsNullOrEmpty ? null : (byte[])value!;
+    }
+
+    /// <inheritdoc />
+    public async Task<byte[]?> GetAsync(string key, CancellationToken token = default)
+    {
+        token.ThrowIfCancellationRequested();
+        var value = await _database.StringGetAsync(key).ConfigureAwait(false);
+        return value.IsNullOrEmpty ? null : (byte[])value!;
+    }
+
+    /// <inheritdoc />
+    public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        var expiry = GetExpiration(options);
+        _database.StringSet(key, value, expiry);
+    }
+
+    /// <inheritdoc />
+    public async Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options,
+        CancellationToken token = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        token.ThrowIfCancellationRequested();
+        var expiry = GetExpiration(options);
+        await _database.StringSetAsync(key, value, expiry).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public void Refresh(string key)
+    {
+        // Redis TTL-based expiry doesn't support refresh without re-setting
+        // This is a no-op for absolute expiration
+        _ = _database.KeyExists(key);
+    }
+
+    /// <inheritdoc />
+    public async Task RefreshAsync(string key, CancellationToken token = default)
+    {
+        token.ThrowIfCancellationRequested();
+        _ = await _database.KeyExistsAsync(key).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public void Remove(string key)
+    {
+        _database.KeyDelete(key);
+    }
+
+    /// <inheritdoc />
+    public async Task RemoveAsync(string key, CancellationToken token = default)
+    {
+        token.ThrowIfCancellationRequested();
+        await _database.KeyDeleteAsync(key).ConfigureAwait(false);
+    }
+
+    private static TimeSpan? GetExpiration(DistributedCacheEntryOptions options)
+    {
+        if (options.AbsoluteExpiration.HasValue)
+            return options.AbsoluteExpiration.Value - DateTimeOffset.UtcNow;
+
+        if (options.AbsoluteExpirationRelativeToNow.HasValue)
+            return options.AbsoluteExpirationRelativeToNow.Value;
+
+        return options.SlidingExpiration;
+    }
+
+    #endregion
 }

--- a/suryami62/Services/RedisCacheService.cs
+++ b/suryami62/Services/RedisCacheService.cs
@@ -75,8 +75,7 @@ public sealed class RedisCacheService : IRedisCacheService, IDistributedCache
             keyList.Add(key);
         }
 
-        if (keyList.Count > 0)
-            await _database.KeyDeleteAsync(keyList.ToArray()).ConfigureAwait(false);
+        await _database.KeyDeleteAsync(keyList.ToArray()).ConfigureAwait(false);
     }
 
     /// <inheritdoc cref="IRedisCacheService.RemoveEntryAsync" />

--- a/suryami62/Startup/WebServiceCollectionExtensions.cs
+++ b/suryami62/Startup/WebServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 using suryami62.Application;
@@ -84,6 +85,8 @@ internal static class WebServiceCollectionExtensions
 
     private static void AddRedisServices(IServiceCollection services)
     {
+        // Register IConnectionMultiplexer as Singleton per Microsoft best practices
+        // https://learn.microsoft.com/azure/redis/best-practices-connection#using-forcereconnect-with-stackexchangeredis
         services.AddSingleton<IConnectionMultiplexer>(sp =>
         {
             var configuration = sp.GetRequiredService<IConfiguration>();
@@ -97,7 +100,20 @@ internal static class WebServiceCollectionExtensions
             return ConnectionMultiplexer.Connect(options);
         });
 
+        // Register RedisCacheService as both IRedisCacheService and IDistributedCache
+        // This allows:
+        // 1. Direct use of IRedisCacheService for advanced operations (pattern-based invalidation)
+        // 2. ASP.NET Core standard IDistributedCache compatibility (sessions, output caching, etc.)
         services.AddScoped<IRedisCacheService, RedisCacheService>();
+        services.AddScoped<IDistributedCache>(sp => sp.GetRequiredService<IRedisCacheService>() as RedisCacheService
+                                                    ?? throw new InvalidOperationException(
+                                                        "RedisCacheService must implement IDistributedCache"));
+
+        // Register stampede protection for cache-aside pattern
+        // Prevents multiple concurrent requests from executing the same expensive operation
+        // https://learn.microsoft.com/aspnet/core/performance/caching/overview?view=aspnetcore-10.0#hybridcache
+        // Note: CacheStampedeProtection is defined in suryami62.Application.Services namespace
+        services.AddSingleton<CacheStampedeProtection>();
     }
 
     /// <summary>


### PR DESCRIPTION
- Standardize the Redis service command array formatting in the compose configuration.
- Add comment clarifying that the service is instantiated without caching or stampede protection for unit tests.
- Add cache‑stampede protection to BlogPostService retrieval logic and replace generic cache removals with entry‑specific removal methods.
- Add CacheStampedeProtection service providing semaphore‑based cache stampede protection with safe disposal and async execution.
- Rename cache removal method to RemoveEntryAsync to explicitly remove an entry by key.
- Add cache‑stampede protection to JourneyHistoryService by injecting CacheStampedeProtection and wrapping cache‑miss retrieval with lock‑based double‑check logic.
- Add cache‑stampede protection to project retrieval methods and replace generic cache removal with RemoveEntryAsync for single‑item eviction.
- Introduce cache‑stampede protection in SiteProfileSettingsStore by injecting a CacheStampedeProtection instance, wrapping cache‑miss retrieval in a lock‑based execution, and updating the cache removal call to RemoveEntryAsync.
- Reformat the LoggerMessage attribute for the repository initialization log to span multiple lines for clearer readability.
- Seal benchmark classes, replace IMemoryCache with concrete MemoryCache, implement IDisposable with proper disposal, and add ConfigureAwait(false) to all asynchronous calls.
- Configure async image load and save operations with ConfigureAwait(false) to prevent context capture.
- Enable InteractiveServer render mode for the About page.
- Add IDistributedCache implementation to RedisCacheService with Get, Set, Refresh and Remove methods, support for pattern‑based removal, cancellation token checks, and remove the IDisposable disposal logic.
- Add a Redis connection singleton, register RedisCacheService as both IRedisCacheService and IDistributedCache, and introduce a CacheStampedeProtection singleton to prevent cache stampedes.