### PR TITLE
docs: enhance OpenGraph meta descriptions with educational focus

### DIFF
--- a/suryami62/Components/Pages/About.razor
+++ b/suryami62/Components/Pages/About.razor
@@ -21,7 +21,7 @@
 <!-- Meta tags for social media sharing -->
 <HeadContent>
     <MetaOpenGraphCard Title="My Personal Bio | suryami62"
-                       Description="A .NET Developer and Physics Teacher bridging the gap between theory and code."
+                       Description="Learn about Surya Ramadhan's journey as a .NET Developer and Physics Teacher. Discover how passion for science and coding shapes problem-solving approaches."
                        Image="@(NavigationManager.BaseUri + Assets["img/socialCard.webp"])"
                        Url="@NavigationManager.Uri"/>
 </HeadContent>

--- a/suryami62/Components/Pages/Home.razor
+++ b/suryami62/Components/Pages/Home.razor
@@ -18,7 +18,7 @@
 <!-- Meta tags for social media sharing (Facebook, Twitter, etc.) -->
 <HeadContent>
     <MetaOpenGraphCard Title="My Personal Blog | suryami62"
-                       Description="Hi, I'm Surya Ramadhan. A .NET Developer and Physics Teacher sharing insights on minimal design, coding, and learning."
+                       Description="Hi, I am Surya Ramadhan. A .NET Developer and Physics Teacher, shares insights on minimal design, coding, and learning from technical and educational perspectives."
                        Image="@(NavigationManager.BaseUri + Assets["img/socialCard.webp"])"
                        Url="@NavigationManager.Uri"/>
 </HeadContent>

--- a/suryami62/Components/Pages/Posts.razor
+++ b/suryami62/Components/Pages/Posts.razor
@@ -21,7 +21,7 @@
 <!-- Meta tags for social media sharing -->
 <HeadContent>
     <MetaOpenGraphCard Title="My Tech Writings | suryami62"
-                       Description="In-depth tutorials and insights from a .NET Developer and Physics Teacher."
+                       Description="Explore in-depth tutorials on .NET and web technologies. Learn coding through an educational approach connecting physics concepts with practical programming."
                        Image="@(NavigationManager.BaseUri + Assets["img/socialCard.webp"])"
                        Url="@NavigationManager.Uri"/>
 </HeadContent>

--- a/suryami62/Components/Pages/Projects.razor
+++ b/suryami62/Components/Pages/Projects.razor
@@ -20,7 +20,7 @@
 <!-- Meta tags for social media sharing -->
 <HeadContent>
     <MetaOpenGraphCard Title="My Selected Projects | suryami62"
-                       Description="A collection of tools and experiments built by a .NET Developer and Physics Teacher."
+                       Description="Discover practical projects combining technology and science. From web applications to coding experiments solving real-world problems with systematic innovation."
                        Image="@(NavigationManager.BaseUri + Assets["img/socialCard.webp"])"
                        Url="@NavigationManager.Uri"/>
 </HeadContent>


### PR DESCRIPTION
- Revise all page descriptions to 110-160 characters for optimal SEO
- Align messaging with technical and educational perspectives
- Improve clarity by connecting .NET development with physics concepts
- Update Home, Posts, Projects, and About pages