### PR TITLE
fix(database): require opt-in for startup migrations

### DIFF
--- a/suryami62/Components/Pages/Projects.razor
+++ b/suryami62/Components/Pages/Projects.razor
@@ -2,7 +2,7 @@
 @using suryami62.Domain.Models
 @inject IProjectService ProjectService
 @inject NavigationManager NavigationManager
-@rendermode InteractiveServer
+@* @rendermode InteractiveServer *@
 
 <PageTitle>My Selected Projects | suryami62</PageTitle>
 

--- a/suryami62/Program.cs
+++ b/suryami62/Program.cs
@@ -16,6 +16,6 @@ app.UseWebStartupPipeline();
 
 app.MapWebEndpoints();
 
-app.ApplyDatabaseMigrations();
+await app.ApplyDatabaseMigrationsAsync().ConfigureAwait(false);
 
-app.Run();
+await app.RunAsync().ConfigureAwait(false);

--- a/suryami62/Startup/WebApplicationExtensions.cs
+++ b/suryami62/Startup/WebApplicationExtensions.cs
@@ -12,6 +12,8 @@ namespace suryami62.Startup;
 
 internal static class WebApplicationExtensions
 {
+    private const string ApplyMigrationsOnStartupConfigurationKey = "Database:ApplyMigrationsOnStartup";
+
     private const string ContentSecurityPolicyValue =
         "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none; " +
         "img-src 'self' data: https:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; " +
@@ -70,9 +72,20 @@ internal static class WebApplicationExtensions
         return app;
     }
 
-    public static WebApplication ApplyDatabaseMigrations(this WebApplication app)
+    public static async Task ApplyDatabaseMigrationsAsync(this WebApplication app)
     {
         ArgumentNullException.ThrowIfNull(app);
+
+        if (!ShouldApplyDatabaseMigrations(app))
+        {
+            var skippedLogger = app.Services.GetRequiredService<ILogger<Program>>();
+            Log.DatabaseMigrationSkipped(
+                skippedLogger,
+                app.Environment.EnvironmentName,
+                ApplyMigrationsOnStartupConfigurationKey);
+
+            return;
+        }
 
         using var scope = app.Services.CreateScope();
 
@@ -81,7 +94,7 @@ internal static class WebApplicationExtensions
         try
         {
             var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-            db.Database.Migrate();
+            await db.Database.MigrateAsync(app.Lifetime.ApplicationStopping).ConfigureAwait(false);
 
             Log.DatabaseMigrationApplied(logger);
         }
@@ -90,8 +103,12 @@ internal static class WebApplicationExtensions
             Log.DatabaseMigrationFailed(logger, ex);
             throw;
         }
+    }
 
-        return app;
+    private static bool ShouldApplyDatabaseMigrations(WebApplication app)
+    {
+        return app.Environment.IsDevelopment()
+               || app.Configuration.GetValue<bool>(ApplyMigrationsOnStartupConfigurationKey);
     }
 
     private static void ConfigureExceptionHandling(WebApplication app)
@@ -156,14 +173,42 @@ internal static class WebApplicationExtensions
 
     private static class Log
     {
+        private static readonly Action<ILogger, Exception?> DatabaseMigrationAppliedMessage = LoggerMessage.Define(
+            LogLevel.Information,
+            new EventId(1, nameof(DatabaseMigrationApplied)),
+            "Applied database migrations at startup.");
+
+        private static readonly Action<ILogger, string, string, Exception?> DatabaseMigrationSkippedMessage =
+            LoggerMessage.Define<string, string>(
+                LogLevel.Information,
+                new EventId(2, nameof(DatabaseMigrationSkipped)),
+                "Skipped database migrations at startup for {EnvironmentName}. Set {ConfigurationKey} to true to opt in.");
+
+        private static readonly Action<ILogger, Exception?> DatabaseMigrationFailedMessage = LoggerMessage.Define(
+            LogLevel.Error,
+            new EventId(3, nameof(DatabaseMigrationFailed)),
+            "An error occurred while applying database migrations at startup.");
+
         public static void DatabaseMigrationApplied(ILogger logger)
         {
-            logger.LogInformation("Applied database migrations at startup.");
+            DatabaseMigrationAppliedMessage(logger, null);
+        }
+
+        public static void DatabaseMigrationSkipped(
+            ILogger logger,
+            string environmentName,
+            string configurationKey)
+        {
+            DatabaseMigrationSkippedMessage(
+                logger,
+                environmentName,
+                configurationKey,
+                null);
         }
 
         public static void DatabaseMigrationFailed(ILogger logger, Exception ex)
         {
-            logger.LogError(ex, "An error occurred while applying database migrations at startup.");
+            DatabaseMigrationFailedMessage(logger, ex);
         }
     }
 }

--- a/suryami62/appsettings.json
+++ b/suryami62/appsettings.json
@@ -9,6 +9,9 @@
     "DefaultConnection": "",
     "RedisConnectionString": ""
   },
+  "Database": {
+    "ApplyMigrationsOnStartup": false
+  },
   "Security": {
     "CanonicalBaseUrl": "",
     "AdminAccess": {


### PR DESCRIPTION
Production startup was applying EF Core migrations automatically, which made deployments mutate the database as a side effect of booting the app.

Gate startup migrations to development by default, add an explicit Database:ApplyMigrationsOnStartup opt-in, and run migrations asynchronously with structured logging for applied, skipped, and failed outcomes.