### PR TITLE
fix(settings): enforce unique setting keys

### DIFF
--- a/suryami62.Domain/Models/DomainModelConstraints.cs
+++ b/suryami62.Domain/Models/DomainModelConstraints.cs
@@ -1,10 +1,12 @@
 namespace suryami62.Domain.Models;
 
-internal static class DomainModelConstraints
+public static class DomainModelConstraints
 {
     public const int TitleMaxLength = 200;
 
     public const int BlogPostSlugMaxLength = 250;
+
+    public const int SettingKeyMaxLength = 250;
 
     public const int JourneyOrganizationMaxLength = 300;
 

--- a/suryami62.Domain/Models/Setting.cs
+++ b/suryami62.Domain/Models/Setting.cs
@@ -10,7 +10,9 @@ public sealed class Setting
 {
     public int Id { get; set; }
 
-    [Required] public string Key { get; set; } = string.Empty;
+    [Required]
+    [StringLength(DomainModelConstraints.SettingKeyMaxLength)]
+    public string Key { get; set; } = string.Empty;
 
     public string Value { get; set; } = string.Empty;
 }

--- a/suryami62.Infrastructure/Data/ApplicationDbContext.cs
+++ b/suryami62.Infrastructure/Data/ApplicationDbContext.cs
@@ -71,6 +71,11 @@ public sealed class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 
             entity.HasIndex(item => new { item.Section, item.DisplayOrder });
         });
+
+        builder.Entity<Setting>(entity =>
+        {
+            entity.HasIndex(setting => setting.Key).IsUnique();
+        });
     }
 
     private static Uri? ParseAbsoluteUri(string? value)

--- a/suryami62.Infrastructure/Data/Migrations/20260529121759_AddUniqueIndexOnSettingsKey.Designer.cs
+++ b/suryami62.Infrastructure/Data/Migrations/20260529121759_AddUniqueIndexOnSettingsKey.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using suryami62.Data;
@@ -11,9 +12,11 @@ using suryami62.Data;
 namespace suryami62.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260529121759_AddUniqueIndexOnSettingsKey")]
+    partial class AddUniqueIndexOnSettingsKey
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/suryami62.Infrastructure/Data/Migrations/20260529121759_AddUniqueIndexOnSettingsKey.cs
+++ b/suryami62.Infrastructure/Data/Migrations/20260529121759_AddUniqueIndexOnSettingsKey.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace suryami62.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUniqueIndexOnSettingsKey : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+            migrationBuilder.Sql(
+                """
+                DO $$
+                BEGIN
+                    IF EXISTS (
+                        SELECT 1
+                        FROM "Settings"
+                        WHERE char_length("Key") > 250
+                    ) THEN
+                        RAISE EXCEPTION 'Cannot constrain Settings.Key to 250 characters because existing rows exceed that length.';
+                    END IF;
+
+                    IF EXISTS (
+                        SELECT 1
+                        FROM "Settings"
+                        GROUP BY "Key"
+                        HAVING COUNT(*) > 1
+                    ) THEN
+                        RAISE EXCEPTION 'Cannot create unique index IX_Settings_Key because duplicate Settings.Key values exist.';
+                    END IF;
+                END $$;
+                """);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Key",
+                table: "Settings",
+                type: "character varying(250)",
+                maxLength: 250,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Settings_Key",
+                table: "Settings",
+                column: "Key",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+            migrationBuilder.DropIndex(
+                name: "IX_Settings_Key",
+                table: "Settings");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Key",
+                table: "Settings",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(250)",
+                oldMaxLength: 250);
+        }
+    }
+}

--- a/suryami62.Infrastructure/Persistence/SettingsRepository.cs
+++ b/suryami62.Infrastructure/Persistence/SettingsRepository.cs
@@ -97,6 +97,13 @@ public sealed class SettingsRepository : ISettingsRepository
     private static void EnsureKey(string key)
     {
         if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("Key cannot be empty.", nameof(key));
+
+        if (key.Length > DomainModelConstraints.SettingKeyMaxLength)
+        {
+            throw new ArgumentException(
+                $"Key cannot exceed {DomainModelConstraints.SettingKeyMaxLength} characters.",
+                nameof(key));
+        }
     }
 
     private async Task<Dictionary<string, Setting>> LoadExistingSettingsByKeyAsync(


### PR DESCRIPTION
Settings could accept duplicate or overly long keys, making updates ambiguous and leaving PostgreSQL without a database-level guard for configuration identity.

This adds a shared key length constraint, validates repository input before database access, and adds a guarded EF migration that fails early when existing data would violate the new unique index.