### PR TITLE
fix(seo): route SEO settings through the settings store

### DIFF
--- a/suryami62.Application/DependencyInjection.cs
+++ b/suryami62.Application/DependencyInjection.cs
@@ -26,6 +26,8 @@ public static class ApplicationServiceCollectionExtensions
 
         services.AddScoped<ApplicationSettingsStore>();
 
+        services.AddScoped<SeoSettingsStore>();
+
         return services;
     }
 }

--- a/suryami62.Application/Services/SeoSettingsStore.cs
+++ b/suryami62.Application/Services/SeoSettingsStore.cs
@@ -1,0 +1,128 @@
+#region
+
+using suryami62.Application.Persistence;
+
+#endregion
+
+namespace suryami62.Services;
+
+public static class SeoSettingKeys
+{
+    public const string BaseUrl = "Seo:BaseUrl";
+
+    public const string EnableSitemap = "Seo:EnableSitemap";
+
+    public const string EnableRobots = "Seo:EnableRobots";
+
+    public const string RobotsDisallow = "Seo:RobotsDisallow";
+}
+
+public sealed record SeoSettings
+{
+    public const string DefaultRobotsDisallowValue = "/Account";
+
+    public string BaseUrl { get; init; } = string.Empty;
+
+    public bool EnableSitemap { get; init; } = true;
+
+    public bool EnableRobots { get; init; } = true;
+
+    public string RobotsDisallow { get; init; } = DefaultRobotsDisallowValue;
+
+    public static SeoSettings Defaults { get; } = new();
+}
+
+public sealed class SeoSettingsStore
+{
+    private const string EnabledSettingValue = "true";
+    private const string DisabledSettingValue = "false";
+
+    private static readonly string[] Keys =
+    [
+        SeoSettingKeys.BaseUrl,
+        SeoSettingKeys.EnableSitemap,
+        SeoSettingKeys.EnableRobots,
+        SeoSettingKeys.RobotsDisallow
+    ];
+
+    private readonly ISettingsRepository _repository;
+
+    public SeoSettingsStore(ISettingsRepository repository)
+    {
+        ArgumentNullException.ThrowIfNull(repository);
+        _repository = repository;
+    }
+
+    public async Task<SeoSettings> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var storedValues = await _repository
+            .GetValuesAsync(Keys, cancellationToken)
+            .ConfigureAwait(false);
+
+        return CreateSettings(storedValues);
+    }
+
+    public async Task SaveAsync(SeoSettings settings, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        var values = CreatePersistedValues(settings);
+        await _repository.UpsertManyAsync(values, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static SeoSettings CreateSettings(IReadOnlyDictionary<string, string> storedValues)
+    {
+        return new SeoSettings
+        {
+            BaseUrl = ReadStoredValue(storedValues, SeoSettingKeys.BaseUrl, SeoSettings.Defaults.BaseUrl),
+            EnableSitemap = ReadBooleanStoredValue(
+                storedValues,
+                SeoSettingKeys.EnableSitemap,
+                SeoSettings.Defaults.EnableSitemap),
+            EnableRobots = ReadBooleanStoredValue(
+                storedValues,
+                SeoSettingKeys.EnableRobots,
+                SeoSettings.Defaults.EnableRobots),
+            RobotsDisallow = ReadStoredValue(
+                storedValues,
+                SeoSettingKeys.RobotsDisallow,
+                SeoSettings.Defaults.RobotsDisallow)
+        };
+    }
+
+    private static string ReadStoredValue(
+        IReadOnlyDictionary<string, string> storedValues,
+        string key,
+        string fallback)
+    {
+        return storedValues.TryGetValue(key, out var value)
+            ? value
+            : fallback;
+    }
+
+    private static bool ReadBooleanStoredValue(
+        IReadOnlyDictionary<string, string> storedValues,
+        string key,
+        bool fallback)
+    {
+        if (!storedValues.TryGetValue(key, out var value)) return fallback;
+
+        return !string.Equals(value, DisabledSettingValue, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static Dictionary<string, string> CreatePersistedValues(SeoSettings settings)
+    {
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [SeoSettingKeys.BaseUrl] = settings.BaseUrl ?? string.Empty,
+            [SeoSettingKeys.EnableSitemap] = FormatBooleanSettingValue(settings.EnableSitemap),
+            [SeoSettingKeys.EnableRobots] = FormatBooleanSettingValue(settings.EnableRobots),
+            [SeoSettingKeys.RobotsDisallow] = settings.RobotsDisallow ?? string.Empty
+        };
+    }
+
+    private static string FormatBooleanSettingValue(bool value)
+    {
+        return value ? EnabledSettingValue : DisabledSettingValue;
+    }
+}

--- a/suryami62/Components/Account/Pages/Admin/SeoFiles.razor
+++ b/suryami62/Components/Account/Pages/Admin/SeoFiles.razor
@@ -1,11 +1,8 @@
 ﻿@page "/Account/Admin/SeoFiles"
 @using Microsoft.AspNetCore.Authorization
-@using Microsoft.EntityFrameworkCore
-@using suryami62.Data
-@using suryami62.Domain.Models
 @attribute [Authorize(Policy = AdminAccessPolicy.Name)]
 @rendermode InteractiveServer
-@inject ApplicationDbContext DbContext
+@inject SeoSettingsStore SeoSettingsStore
 
 <PageTitle>SEO Files Configuration</PageTitle>
 
@@ -78,21 +75,6 @@
     private const string ValidationSummaryClass = "text-sm font-bold text-red-600 dark:text-red-400";
     private const string SuccessMessageClass = "neo-card mb-4 bg-green-400 px-4 py-3 font-bold text-black";
     private const string PrimaryButtonClass = "neo-button w-full text-center";
-    private const string SeoBaseUrlKey = "Seo:BaseUrl";
-    private const string SeoEnableSitemapKey = "Seo:EnableSitemap";
-    private const string SeoEnableRobotsKey = "Seo:EnableRobots";
-    private const string SeoRobotsDisallowKey = "Seo:RobotsDisallow";
-    private const string DefaultRobotsDisallowValue = "/Account";
-    private const string EnabledSettingValue = "true";
-    private const string DisabledSettingValue = "false";
-
-    private static readonly string[] SeoSettingKeys =
-    [
-        SeoBaseUrlKey,
-        SeoEnableSitemapKey,
-        SeoEnableRobotsKey,
-        SeoRobotsDisallowKey
-    ];
 
     private bool HasSuccessMessage { get; set; }
 
@@ -112,95 +94,35 @@
 
     private async Task LoadFormInputAsync()
     {
-        var settingsByKey = await LoadSeoSettingsByKeyAsync();
-        FormInput = CreateInputModel(settingsByKey);
+        var settings = await SeoSettingsStore.GetAsync();
+        FormInput = CreateInputModel(settings);
     }
 
-    private async Task<Dictionary<string, string>> LoadSeoSettingsByKeyAsync()
-    {
-        return await DbContext.Settings
-            .AsNoTracking()
-            .Where(setting => SeoSettingKeys.Contains(setting.Key))
-            .ToDictionaryAsync(setting => setting.Key, setting => setting.Value);
-    }
-
-    private static InputModel CreateInputModel(IReadOnlyDictionary<string, string> settingsByKey)
+    private static InputModel CreateInputModel(SeoSettings settings)
     {
         return new InputModel
         {
-            BaseUrl = GetSettingValue(settingsByKey, SeoBaseUrlKey),
-            EnableSitemap = GetBooleanSettingValue(settingsByKey, SeoEnableSitemapKey, true),
-            EnableRobots = GetBooleanSettingValue(settingsByKey, SeoEnableRobotsKey, true),
-            RobotsDisallow = GetSettingValue(settingsByKey, SeoRobotsDisallowKey, DefaultRobotsDisallowValue)
+            BaseUrl = settings.BaseUrl,
+            EnableSitemap = settings.EnableSitemap,
+            EnableRobots = settings.EnableRobots,
+            RobotsDisallow = settings.RobotsDisallow
         };
-    }
-
-    private static string GetSettingValue(
-        IReadOnlyDictionary<string, string> settingsByKey,
-        string key,
-        string defaultValue = "")
-    {
-        return settingsByKey.TryGetValue(key, out var value)
-            ? value
-            : defaultValue;
-    }
-
-    private static bool GetBooleanSettingValue(
-        IReadOnlyDictionary<string, string> settingsByKey,
-        string key,
-        bool defaultValue)
-    {
-        if (!settingsByKey.TryGetValue(key, out var value))
-        {
-            return defaultValue;
-        }
-
-        return !string.Equals(value, DisabledSettingValue, StringComparison.OrdinalIgnoreCase);
     }
 
     private async Task SaveSeoSettingsAsync()
     {
-        foreach (var (key, value) in CreateSettingsToPersist())
-        {
-            await SaveSettingAsync(key, value);
-        }
-
-        // Saving once after all updates avoids partial writes when one later setting fails.
-        await DbContext.SaveChangesAsync();
+        await SeoSettingsStore.SaveAsync(CreateSettingsFromForm());
     }
 
-    private Dictionary<string, string> CreateSettingsToPersist()
+    private SeoSettings CreateSettingsFromForm()
     {
-        return new Dictionary<string, string>
+        return new SeoSettings
         {
-            [SeoBaseUrlKey] = FormInput.BaseUrl ?? string.Empty,
-            [SeoEnableSitemapKey] = FormatBooleanSettingValue(FormInput.EnableSitemap),
-            [SeoEnableRobotsKey] = FormatBooleanSettingValue(FormInput.EnableRobots),
-            [SeoRobotsDisallowKey] = FormInput.RobotsDisallow ?? string.Empty
+            BaseUrl = FormInput.BaseUrl ?? string.Empty,
+            EnableSitemap = FormInput.EnableSitemap,
+            EnableRobots = FormInput.EnableRobots,
+            RobotsDisallow = FormInput.RobotsDisallow ?? string.Empty
         };
-    }
-
-    private static string FormatBooleanSettingValue(bool value)
-    {
-        return value ? EnabledSettingValue : DisabledSettingValue;
-    }
-
-    private async Task SaveSettingAsync(string key, string value)
-    {
-        var setting = await FindSettingAsync(key);
-        if (setting is null)
-        {
-            setting = new Setting { Key = key, Value = value };
-            DbContext.Settings.Add(setting);
-            return;
-        }
-
-        setting.Value = value;
-    }
-
-    private Task<Setting?> FindSettingAsync(string key)
-    {
-        return DbContext.Settings.FirstOrDefaultAsync(setting => setting.Key == key);
     }
 
     private sealed class InputModel
@@ -208,7 +130,7 @@
         public string? BaseUrl { get; set; }
         public bool EnableSitemap { get; set; } = true;
         public bool EnableRobots { get; set; } = true;
-        public string? RobotsDisallow { get; set; } = DefaultRobotsDisallowValue;
+        public string? RobotsDisallow { get; set; } = SeoSettings.DefaultRobotsDisallowValue;
     }
 
 }

--- a/suryami62/Startup/SeoEndpointRouteBuilderExtensions.cs
+++ b/suryami62/Startup/SeoEndpointRouteBuilderExtensions.cs
@@ -2,7 +2,6 @@
 
 using System.Globalization;
 using System.Text;
-using suryami62.Application.Persistence;
 using suryami62.Domain.Models;
 using suryami62.Services;
 
@@ -27,14 +26,14 @@ internal static class SeoEndpointRouteBuilderExtensions
 
     private static async Task<IResult> GetSitemapAsync(
         IConfiguration configuration,
-        ISettingsRepository settingsRepository,
+        SeoSettingsStore seoSettingsStore,
         IBlogPostService blogPostService)
     {
-        var sitemapEnabled =
-            await IsSeoDocumentEnabledAsync(settingsRepository, "Seo:EnableSitemap").ConfigureAwait(false);
-        if (!sitemapEnabled) return Results.NotFound();
+        var seoSettings = await seoSettingsStore.GetAsync().ConfigureAwait(false);
 
-        var canonicalBaseUrl = await GetCanonicalBaseUrlAsync(configuration, settingsRepository).ConfigureAwait(false);
+        if (!seoSettings.EnableSitemap) return Results.NotFound();
+
+        var canonicalBaseUrl = GetCanonicalBaseUrl(configuration, seoSettings);
         if (canonicalBaseUrl is null) return CreateMissingCanonicalBaseUrlProblem("sitemap.xml");
 
         (IEnumerable<BlogPost> posts, _) = await blogPostService.GetPostsAsync().ConfigureAwait(false);
@@ -45,40 +44,29 @@ internal static class SeoEndpointRouteBuilderExtensions
 
     private static async Task<IResult> GetRobotsAsync(
         IConfiguration configuration,
-        ISettingsRepository settingsRepository)
+        SeoSettingsStore seoSettingsStore)
     {
-        var robotsEnabled =
-            await IsSeoDocumentEnabledAsync(settingsRepository, "Seo:EnableRobots").ConfigureAwait(false);
-        if (!robotsEnabled) return Results.NotFound();
+        var seoSettings = await seoSettingsStore.GetAsync().ConfigureAwait(false);
 
-        var canonicalBaseUrl = await GetCanonicalBaseUrlAsync(configuration, settingsRepository).ConfigureAwait(false);
+        if (!seoSettings.EnableRobots) return Results.NotFound();
+
+        var canonicalBaseUrl = GetCanonicalBaseUrl(configuration, seoSettings);
         if (canonicalBaseUrl is null) return CreateMissingCanonicalBaseUrlProblem("robots.txt");
 
-        var disallowList = await settingsRepository.GetValueAsync("Seo:RobotsDisallow").ConfigureAwait(false);
+        var disallowList = seoSettings.RobotsDisallow;
         if (string.IsNullOrWhiteSpace(disallowList)) disallowList = "/Account";
 
         var robotsText = BuildRobotsText(canonicalBaseUrl, disallowList);
         return Results.Text(robotsText, "text/plain; charset=utf-8");
     }
 
-    private static async Task<bool> IsSeoDocumentEnabledAsync(ISettingsRepository settingsRepository, string settingKey)
-    {
-        var storedValue = await settingsRepository.GetValueAsync(settingKey).ConfigureAwait(false);
-
-        var isDisabled = string.Equals(storedValue, "false", StringComparison.OrdinalIgnoreCase);
-
-        return !isDisabled;
-    }
-
-    private static async Task<string?> GetCanonicalBaseUrlAsync(
+    private static string? GetCanonicalBaseUrl(
         IConfiguration configuration,
-        ISettingsRepository settingsRepository)
+        SeoSettings seoSettings)
     {
-        var settingsBaseUrl = await settingsRepository.GetValueAsync("Seo:BaseUrl").ConfigureAwait(false);
-
         var configuredBaseUrl = configuration["Security:CanonicalBaseUrl"];
 
-        return ResolveCanonicalBaseUrl(settingsBaseUrl, configuredBaseUrl);
+        return ResolveCanonicalBaseUrl(seoSettings.BaseUrl, configuredBaseUrl);
     }
 
     private static string? ResolveCanonicalBaseUrl(string? settingsBaseUrl, string? configuredBaseUrl)


### PR DESCRIPTION
The SEO admin page was reading and writing settings directly through the database context, bypassing the repository and cache path used by the rest of the application.

This adds a dedicated SEO settings store and routes both the admin form and SEO endpoints through it, keeping sitemap and robots settings consistent with the shared settings persistence flow.