### PR TITLE
perf(data): add indexes for common listing queries

### DIFF
--- a/suryami62.Infrastructure/Data/ApplicationDbContext.cs
+++ b/suryami62.Infrastructure/Data/ApplicationDbContext.cs
@@ -55,6 +55,8 @@ public sealed class ApplicationDbContext : IdentityDbContext<ApplicationUser>
             entity.Property(p => p.RepoUrl).HasConversion(uriConverter);
             entity.Property(p => p.DemoUrl).HasConversion(uriConverter);
             entity.Property(p => p.ImageUrl).HasConversion(uriConverter);
+
+            entity.HasIndex(p => p.DisplayOrder);
         });
 
         builder.Entity<BlogPost>(entity =>
@@ -63,6 +65,7 @@ public sealed class ApplicationDbContext : IdentityDbContext<ApplicationUser>
             entity.Property(p => p.ImageUrl).HasConversion(uriConverter);
 
             entity.HasIndex(p => p.Slug).IsUnique();
+            entity.HasIndex(p => new { p.IsPublished, p.Date }).IsDescending(false, true);
         });
 
         builder.Entity<JourneyHistory>(entity =>

--- a/suryami62.Infrastructure/Data/Migrations/20260529155305_AddQueryIndexes.Designer.cs
+++ b/suryami62.Infrastructure/Data/Migrations/20260529155305_AddQueryIndexes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using suryami62.Data;
@@ -11,9 +12,11 @@ using suryami62.Data;
 namespace suryami62.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260529155305_AddQueryIndexes")]
+    partial class AddQueryIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/suryami62.Infrastructure/Data/Migrations/20260529155305_AddQueryIndexes.cs
+++ b/suryami62.Infrastructure/Data/Migrations/20260529155305_AddQueryIndexes.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace suryami62.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddQueryIndexes : Migration
+    {
+        private static readonly string[] BlogPostPublishedDateIndexColumns = ["IsPublished", "Date"];
+
+        private static readonly bool[] BlogPostPublishedDateIndexDescending = [false, true];
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_DisplayOrder",
+                table: "Projects",
+                column: "DisplayOrder");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BlogPosts_IsPublished_Date",
+                table: "BlogPosts",
+                columns: BlogPostPublishedDateIndexColumns,
+                descending: BlogPostPublishedDateIndexDescending);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+            migrationBuilder.DropIndex(
+                name: "IX_Projects_DisplayOrder",
+                table: "Projects");
+
+            migrationBuilder.DropIndex(
+                name: "IX_BlogPosts_IsPublished_Date",
+                table: "BlogPosts");
+        }
+    }
+}


### PR DESCRIPTION
Public blog and project pages sort and filter on columns that were not fully covered by the database model, which could force PostgreSQL to scan more rows as content grows.

This adds EF Core indexes for project display ordering and published blog post date ordering, with a migration that creates the matching PostgreSQL indexes.