### PR TITLE
perf(blog): add trigram indexes for post search

### DIFF
--- a/suryami62.Infrastructure/Data/ApplicationDbContext.cs
+++ b/suryami62.Infrastructure/Data/ApplicationDbContext.cs
@@ -46,6 +46,8 @@ public sealed class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 
         base.OnModelCreating(builder);
 
+        builder.HasPostgresExtension("pg_trgm");
+
         var uriConverter = new ValueConverter<Uri?, string?>(
             uri => uri == null ? null : uri.ToString(),
             value => ParseAbsoluteUri(value));
@@ -66,6 +68,8 @@ public sealed class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 
             entity.HasIndex(p => p.Slug).IsUnique();
             entity.HasIndex(p => new { p.IsPublished, p.Date }).IsDescending(false, true);
+            entity.HasIndex(p => p.Title).HasMethod("gin").HasOperators("gin_trgm_ops");
+            entity.HasIndex(p => p.Summary).HasMethod("gin").HasOperators("gin_trgm_ops");
         });
 
         builder.Entity<JourneyHistory>(entity =>

--- a/suryami62.Infrastructure/Data/Migrations/20260529164014_AddBlogPostTrigramSearchIndexes.Designer.cs
+++ b/suryami62.Infrastructure/Data/Migrations/20260529164014_AddBlogPostTrigramSearchIndexes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using suryami62.Data;
@@ -11,9 +12,11 @@ using suryami62.Data;
 namespace suryami62.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260529164014_AddBlogPostTrigramSearchIndexes")]
+    partial class AddBlogPostTrigramSearchIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/suryami62.Infrastructure/Data/Migrations/20260529164014_AddBlogPostTrigramSearchIndexes.cs
+++ b/suryami62.Infrastructure/Data/Migrations/20260529164014_AddBlogPostTrigramSearchIndexes.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace suryami62.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBlogPostTrigramSearchIndexes : Migration
+    {
+        private static readonly string[] BlogPostSearchIndexOperators = ["gin_trgm_ops"];
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:PostgresExtension:pg_trgm", ",,");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BlogPosts_Summary",
+                table: "BlogPosts",
+                column: "Summary")
+                .Annotation("Npgsql:IndexMethod", "gin")
+                .Annotation("Npgsql:IndexOperators", BlogPostSearchIndexOperators);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BlogPosts_Title",
+                table: "BlogPosts",
+                column: "Title")
+                .Annotation("Npgsql:IndexMethod", "gin")
+                .Annotation("Npgsql:IndexOperators", BlogPostSearchIndexOperators);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+            migrationBuilder.DropIndex(
+                name: "IX_BlogPosts_Summary",
+                table: "BlogPosts");
+
+            migrationBuilder.DropIndex(
+                name: "IX_BlogPosts_Title",
+                table: "BlogPosts");
+
+            migrationBuilder.AlterDatabase()
+                .OldAnnotation("Npgsql:PostgresExtension:pg_trgm", ",,");
+        }
+    }
+}

--- a/suryami62.Infrastructure/Persistence/BlogPostRepository.cs
+++ b/suryami62.Infrastructure/Persistence/BlogPostRepository.cs
@@ -11,6 +11,8 @@ namespace suryami62.Infrastructure.Persistence;
 
 public sealed class BlogPostRepository : IBlogPostRepository
 {
+    private const string LikeEscapeCharacter = "\\";
+
     private readonly ApplicationDbContext _context;
 
     public BlogPostRepository(ApplicationDbContext context)
@@ -115,11 +117,26 @@ public sealed class BlogPostRepository : IBlogPostRepository
         if (onlyPublished) query = query.Where(post => post.IsPublished);
 
         if (!string.IsNullOrWhiteSpace(searchTerm))
+        {
+            var searchPattern = CreateContainsSearchPattern(searchTerm);
+
             query = query.Where(post =>
-                post.Title.Contains(searchTerm) ||
-                post.Summary.Contains(searchTerm));
+                EF.Functions.ILike(post.Title, searchPattern, LikeEscapeCharacter) ||
+                EF.Functions.ILike(post.Summary, searchPattern, LikeEscapeCharacter));
+        }
 
         return query;
+    }
+
+    private static string CreateContainsSearchPattern(string searchTerm)
+    {
+        var escapedTerm = searchTerm
+            .Trim()
+            .Replace(LikeEscapeCharacter, LikeEscapeCharacter + LikeEscapeCharacter, StringComparison.Ordinal)
+            .Replace("%", LikeEscapeCharacter + "%", StringComparison.Ordinal)
+            .Replace("_", LikeEscapeCharacter + "_", StringComparison.Ordinal);
+
+        return $"%{escapedTerm}%";
     }
 
     private static async Task<List<BlogPost>> LoadPagedPostsAsync(


### PR DESCRIPTION
Blog search previously filtered title and summary text with Contains, which could force slower scans as the post table grows.

Enable PostgreSQL pg_trgm support, add GIN trigram indexes for the searchable columns, and use escaped ILIKE patterns so wildcard characters in user input stay literal.