### PR TITLE
fix(data): propagate cancellation through repository operations

### DIFF
--- a/suryami62.Application/Persistence/IBlogPostRepository.cs
+++ b/suryami62.Application/Persistence/IBlogPostRepository.cs
@@ -12,17 +12,18 @@ public interface IBlogPostRepository
         bool onlyPublished = true,
         int? skip = null,
         int? take = null,
-        string? searchTerm = null);
+        string? searchTerm = null,
+        CancellationToken cancellationToken = default);
 
-    Task<BlogPost?> GetBySlugAsync(string slug);
+    Task<BlogPost?> GetBySlugAsync(string slug, CancellationToken cancellationToken = default);
 
-    Task<bool> SlugExistsAsync(string slug, int? excludeId = null);
+    Task<bool> SlugExistsAsync(string slug, int? excludeId = null, CancellationToken cancellationToken = default);
 
-    Task<BlogPost?> GetByIdAsync(int id);
+    Task<BlogPost?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
 
-    Task<BlogPost> CreateAsync(BlogPost post);
+    Task<BlogPost> CreateAsync(BlogPost post, CancellationToken cancellationToken = default);
 
-    Task UpdateAsync(BlogPost post);
+    Task UpdateAsync(BlogPost post, CancellationToken cancellationToken = default);
 
-    Task DeleteAsync(int id);
+    Task DeleteAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/suryami62.Application/Persistence/IJourneyHistoryRepository.cs
+++ b/suryami62.Application/Persistence/IJourneyHistoryRepository.cs
@@ -8,9 +8,11 @@ namespace suryami62.Application.Persistence;
 
 public interface IJourneyHistoryRepository
 {
-    Task<List<JourneyHistory>> GetBySectionAsync(JourneySection section);
+    Task<List<JourneyHistory>> GetBySectionAsync(
+        JourneySection section,
+        CancellationToken cancellationToken = default);
 
-    Task<JourneyHistory> CreateAsync(JourneyHistory item);
+    Task<JourneyHistory> CreateAsync(JourneyHistory item, CancellationToken cancellationToken = default);
 
-    Task DeleteAsync(int id);
+    Task DeleteAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/suryami62.Application/Persistence/IProjectRepository.cs
+++ b/suryami62.Application/Persistence/IProjectRepository.cs
@@ -8,13 +8,16 @@ namespace suryami62.Application.Persistence;
 
 public interface IProjectRepository
 {
-    Task<(List<Project> Items, int Total)> GetProjectsAsync(int? skip = null, int? take = null);
+    Task<(List<Project> Items, int Total)> GetProjectsAsync(
+        int? skip = null,
+        int? take = null,
+        CancellationToken cancellationToken = default);
 
-    Task<Project?> GetByIdAsync(int id);
+    Task<Project?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
 
-    Task<Project> CreateAsync(Project project);
+    Task<Project> CreateAsync(Project project, CancellationToken cancellationToken = default);
 
-    Task UpdateAsync(Project project);
+    Task UpdateAsync(Project project, CancellationToken cancellationToken = default);
 
-    Task DeleteAsync(int id);
+    Task DeleteAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/suryami62.Application/Services/BlogPostService.cs
+++ b/suryami62.Application/Services/BlogPostService.cs
@@ -14,21 +14,25 @@ public interface IBlogPostService
         bool onlyPublished = true,
         int? skip = null,
         int? take = null,
-        string? searchTerm = null);
+        string? searchTerm = null,
+        CancellationToken cancellationToken = default);
 
-    Task<BlogPost?> GetPostBySlugAsync(string slug);
+    Task<BlogPost?> GetPostBySlugAsync(string slug, CancellationToken cancellationToken = default);
 
-    Task<BlogPost?> GetPostByIdAsync(int id);
+    Task<BlogPost?> GetPostByIdAsync(int id, CancellationToken cancellationToken = default);
 
-    Task<BlogPost> CreatePostAsync(BlogPost post);
+    Task<BlogPost> CreatePostAsync(BlogPost post, CancellationToken cancellationToken = default);
 
-    Task UpdatePostAsync(BlogPost post);
+    Task UpdatePostAsync(BlogPost post, CancellationToken cancellationToken = default);
 
-    Task DeletePostAsync(int id);
+    Task DeletePostAsync(int id, CancellationToken cancellationToken = default);
 
-    Task<string> GenerateUniqueSlugAsync(string title, int? excludeId = null);
+    Task<string> GenerateUniqueSlugAsync(
+        string title,
+        int? excludeId = null,
+        CancellationToken cancellationToken = default);
 
-    Task<bool> SlugExistsAsync(string slug, int? excludeId = null);
+    Task<bool> SlugExistsAsync(string slug, int? excludeId = null, CancellationToken cancellationToken = default);
 }
 
 public sealed class BlogPostService : IBlogPostService
@@ -57,13 +61,14 @@ public sealed class BlogPostService : IBlogPostService
         bool onlyPublished = true,
         int? skip = null,
         int? take = null,
-        string? searchTerm = null)
+        string? searchTerm = null,
+        CancellationToken cancellationToken = default)
     {
         var cacheKey = $"{CacheKeyPrefix}list:{onlyPublished}:{skip ?? 0}:{take ?? 0}:{searchTerm ?? ""}";
 
         if (_cacheService != null)
         {
-            var cached = await _cacheService.GetAsync<CachedBlogPostList>(cacheKey)
+            var cached = await _cacheService.GetAsync<CachedBlogPostList>(cacheKey, cancellationToken)
                 .ConfigureAwait(false);
 
             if (cached != null)
@@ -76,40 +81,42 @@ public sealed class BlogPostService : IBlogPostService
                 .ExecuteAsync(cacheKey, async () =>
                 {
                     var doubleCheck = await _cacheService
-                        .GetAsync<CachedBlogPostList>(cacheKey)
+                        .GetAsync<CachedBlogPostList>(cacheKey, cancellationToken)
                         .ConfigureAwait(false);
 
                     if (doubleCheck != null) return (doubleCheck.Items, doubleCheck.Total);
 
                     var dbResult = await _repository
-                        .GetPostsAsync(onlyPublished, skip, take, searchTerm)
+                        .GetPostsAsync(onlyPublished, skip, take, searchTerm, cancellationToken)
                         .ConfigureAwait(false);
 
                     await _cacheService.SetAsync(
                         cacheKey,
                         new CachedBlogPostList(dbResult.Items, dbResult.Total),
-                        CacheExpiration).ConfigureAwait(false);
+                        CacheExpiration,
+                        cancellationToken).ConfigureAwait(false);
 
                     return dbResult;
-                }).ConfigureAwait(false);
+                }, cancellationToken).ConfigureAwait(false);
 
             return result;
         }
 
         var fallbackResult = await _repository
-            .GetPostsAsync(onlyPublished, skip, take, searchTerm)
+            .GetPostsAsync(onlyPublished, skip, take, searchTerm, cancellationToken)
             .ConfigureAwait(false);
 
         if (_cacheService != null)
             await _cacheService.SetAsync(
                 cacheKey,
                 new CachedBlogPostList(fallbackResult.Items, fallbackResult.Total),
-                CacheExpiration).ConfigureAwait(false);
+                CacheExpiration,
+                cancellationToken).ConfigureAwait(false);
 
         return fallbackResult;
     }
 
-    public async Task<BlogPost?> GetPostBySlugAsync(string slug)
+    public async Task<BlogPost?> GetPostBySlugAsync(string slug, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(slug)) return null;
 
@@ -117,99 +124,104 @@ public sealed class BlogPostService : IBlogPostService
 
         if (_cacheService != null)
         {
-            var cached = await _cacheService.GetAsync<BlogPost>(cacheKey).ConfigureAwait(false);
+            var cached = await _cacheService.GetAsync<BlogPost>(cacheKey, cancellationToken).ConfigureAwait(false);
             if (cached != null) return cached;
         }
 
-        var post = await _repository.GetBySlugAsync(slug).ConfigureAwait(false);
+        var post = await _repository.GetBySlugAsync(slug, cancellationToken).ConfigureAwait(false);
 
         if (_cacheService != null && post != null)
-            await _cacheService.SetAsync(cacheKey, post, CacheExpiration).ConfigureAwait(false);
+            await _cacheService.SetAsync(cacheKey, post, CacheExpiration, cancellationToken).ConfigureAwait(false);
 
         return post;
     }
 
-    public async Task<BlogPost?> GetPostByIdAsync(int id)
+    public async Task<BlogPost?> GetPostByIdAsync(int id, CancellationToken cancellationToken = default)
     {
         var cacheKey = $"{CacheKeyPrefix}id:{id}";
 
         if (_cacheService != null)
         {
-            var cached = await _cacheService.GetAsync<BlogPost>(cacheKey).ConfigureAwait(false);
+            var cached = await _cacheService.GetAsync<BlogPost>(cacheKey, cancellationToken).ConfigureAwait(false);
             if (cached != null) return cached;
         }
 
-        var post = await _repository.GetByIdAsync(id).ConfigureAwait(false);
+        var post = await _repository.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
 
         if (_cacheService != null && post != null)
-            await _cacheService.SetAsync(cacheKey, post, CacheExpiration).ConfigureAwait(false);
+            await _cacheService.SetAsync(cacheKey, post, CacheExpiration, cancellationToken).ConfigureAwait(false);
 
         return post;
     }
 
-    public async Task<BlogPost> CreatePostAsync(BlogPost post)
+    public async Task<BlogPost> CreatePostAsync(
+        BlogPost post,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(post);
 
         if (string.IsNullOrWhiteSpace(post.Slug))
             throw new ArgumentException("Post slug cannot be empty.", nameof(post));
 
-        if (await _repository.SlugExistsAsync(post.Slug).ConfigureAwait(false))
+        if (await _repository.SlugExistsAsync(post.Slug, cancellationToken: cancellationToken).ConfigureAwait(false))
             throw new InvalidOperationException($"A post with slug '{post.Slug}' already exists.");
 
-        var result = await _repository.CreateAsync(post).ConfigureAwait(false);
+        var result = await _repository.CreateAsync(post, cancellationToken).ConfigureAwait(false);
 
         if (_cacheService != null)
-            await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}list:*").ConfigureAwait(false);
+            await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}list:*", cancellationToken).ConfigureAwait(false);
 
         return result;
     }
 
-    public async Task UpdatePostAsync(BlogPost post)
+    public async Task UpdatePostAsync(BlogPost post, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(post);
 
         if (string.IsNullOrWhiteSpace(post.Slug))
             throw new ArgumentException("Post slug cannot be empty.", nameof(post));
 
-        if (await _repository.SlugExistsAsync(post.Slug, post.Id).ConfigureAwait(false))
+        if (await _repository.SlugExistsAsync(post.Slug, post.Id, cancellationToken).ConfigureAwait(false))
             throw new InvalidOperationException($"A post with slug '{post.Slug}' already exists.");
 
-        await _repository.UpdateAsync(post).ConfigureAwait(false);
+        await _repository.UpdateAsync(post, cancellationToken).ConfigureAwait(false);
 
         if (_cacheService != null)
         {
-            await _cacheService.RemoveEntryAsync($"{CacheKeyPrefix}slug:{post.Slug}")
+            await _cacheService.RemoveEntryAsync($"{CacheKeyPrefix}slug:{post.Slug}", cancellationToken)
                 .ConfigureAwait(false);
-            await _cacheService.RemoveEntryAsync($"{CacheKeyPrefix}id:{post.Id}")
+            await _cacheService.RemoveEntryAsync($"{CacheKeyPrefix}id:{post.Id}", cancellationToken)
                 .ConfigureAwait(false);
 
-            await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}list:*")
+            await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}list:*", cancellationToken)
                 .ConfigureAwait(false);
         }
     }
 
-    public async Task DeletePostAsync(int id)
+    public async Task DeletePostAsync(int id, CancellationToken cancellationToken = default)
     {
-        var post = await _repository.GetByIdAsync(id).ConfigureAwait(false);
+        var post = await _repository.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
 
-        await _repository.DeleteAsync(id).ConfigureAwait(false);
+        await _repository.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
 
         if (_cacheService != null)
         {
             if (post != null)
-                await _cacheService.RemoveEntryAsync($"{CacheKeyPrefix}slug:{post.Slug}")
+                await _cacheService.RemoveEntryAsync($"{CacheKeyPrefix}slug:{post.Slug}", cancellationToken)
                     .ConfigureAwait(false);
 
-            await _cacheService.RemoveEntryAsync($"{CacheKeyPrefix}id:{id}")
+            await _cacheService.RemoveEntryAsync($"{CacheKeyPrefix}id:{id}", cancellationToken)
                 .ConfigureAwait(false);
 
-            await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}list:*")
+            await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}list:*", cancellationToken)
                 .ConfigureAwait(false);
         }
     }
 
-    public async Task<string> GenerateUniqueSlugAsync(string title, int? excludeId = null)
+    public async Task<string> GenerateUniqueSlugAsync(
+        string title,
+        int? excludeId = null,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(title))
             return string.Empty;
@@ -218,23 +230,27 @@ public sealed class BlogPostService : IBlogPostService
         if (string.IsNullOrEmpty(baseSlug))
             return string.Empty;
 
-        if (!await _repository.SlugExistsAsync(baseSlug, excludeId).ConfigureAwait(false))
+        if (!await _repository.SlugExistsAsync(baseSlug, excludeId, cancellationToken).ConfigureAwait(false))
             return baseSlug;
 
         var counter = 2;
         string candidate;
         do
         {
+            cancellationToken.ThrowIfCancellationRequested();
             candidate = $"{baseSlug}-{counter}";
             counter++;
-        } while (await _repository.SlugExistsAsync(candidate, excludeId).ConfigureAwait(false));
+        } while (await _repository.SlugExistsAsync(candidate, excludeId, cancellationToken).ConfigureAwait(false));
 
         return candidate;
     }
 
-    public Task<bool> SlugExistsAsync(string slug, int? excludeId = null)
+    public Task<bool> SlugExistsAsync(
+        string slug,
+        int? excludeId = null,
+        CancellationToken cancellationToken = default)
     {
-        return _repository.SlugExistsAsync(slug, excludeId);
+        return _repository.SlugExistsAsync(slug, excludeId, cancellationToken);
     }
 
     private static string CreateSlug(string title)

--- a/suryami62.Application/Services/CacheStampedeProtection.cs
+++ b/suryami62.Application/Services/CacheStampedeProtection.cs
@@ -45,13 +45,16 @@ public sealed class CacheStampedeProtection : IDisposable
         }
     }
 
-    public async Task<T> ExecuteAsync<T>(string key, Func<Task<T>> factory)
+    public async Task<T> ExecuteAsync<T>(
+        string key,
+        Func<Task<T>> factory,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(factory);
 
         var semaphore = GetLock(key);
 
-        await semaphore.WaitAsync().ConfigureAwait(false);
+        await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         try
         {

--- a/suryami62.Application/Services/JourneyHistoryService.cs
+++ b/suryami62.Application/Services/JourneyHistoryService.cs
@@ -9,11 +9,13 @@ namespace suryami62.Services;
 
 public interface IJourneyHistoryService
 {
-    Task<List<JourneyHistory>> GetBySectionAsync(JourneySection section);
+    Task<List<JourneyHistory>> GetBySectionAsync(
+        JourneySection section,
+        CancellationToken cancellationToken = default);
 
-    Task<JourneyHistory> CreateAsync(JourneyHistory item);
+    Task<JourneyHistory> CreateAsync(JourneyHistory item, CancellationToken cancellationToken = default);
 
-    Task DeleteAsync(int id);
+    Task DeleteAsync(int id, CancellationToken cancellationToken = default);
 }
 
 public sealed class JourneyHistoryService : IJourneyHistoryService
@@ -38,14 +40,16 @@ public sealed class JourneyHistoryService : IJourneyHistoryService
         _stampedeProtection = stampedeProtection;
     }
 
-    public async Task<List<JourneyHistory>> GetBySectionAsync(JourneySection section)
+    public async Task<List<JourneyHistory>> GetBySectionAsync(
+        JourneySection section,
+        CancellationToken cancellationToken = default)
     {
         var cacheKey = $"{CacheKeyPrefix}section:{section}";
 
         if (_cacheService != null)
         {
             var cached = await _cacheService
-                .GetAsync<List<JourneyHistory>>(cacheKey)
+                .GetAsync<List<JourneyHistory>>(cacheKey, cancellationToken)
                 .ConfigureAwait(false);
 
             if (cached != null)
@@ -58,53 +62,55 @@ public sealed class JourneyHistoryService : IJourneyHistoryService
                 .ExecuteAsync(cacheKey, async () =>
                 {
                     var doubleCheck = await _cacheService
-                        .GetAsync<List<JourneyHistory>>(cacheKey)
+                        .GetAsync<List<JourneyHistory>>(cacheKey, cancellationToken)
                         .ConfigureAwait(false);
 
                     if (doubleCheck != null) return doubleCheck;
 
                     var items = await _repository
-                        .GetBySectionAsync(section)
+                        .GetBySectionAsync(section, cancellationToken)
                         .ConfigureAwait(false);
 
-                    await _cacheService.SetAsync(cacheKey, items, CacheExpiration)
+                    await _cacheService.SetAsync(cacheKey, items, CacheExpiration, cancellationToken)
                         .ConfigureAwait(false);
 
                     return items;
-                }).ConfigureAwait(false);
+                }, cancellationToken).ConfigureAwait(false);
 
             return result;
         }
 
         var fallbackItems = await _repository
-            .GetBySectionAsync(section)
+            .GetBySectionAsync(section, cancellationToken)
             .ConfigureAwait(false);
 
         if (_cacheService != null)
-            await _cacheService.SetAsync(cacheKey, fallbackItems, CacheExpiration)
+            await _cacheService.SetAsync(cacheKey, fallbackItems, CacheExpiration, cancellationToken)
                 .ConfigureAwait(false);
 
         return fallbackItems;
     }
 
-    public async Task<JourneyHistory> CreateAsync(JourneyHistory item)
+    public async Task<JourneyHistory> CreateAsync(
+        JourneyHistory item,
+        CancellationToken cancellationToken = default)
     {
-        var result = await _repository.CreateAsync(item)
+        var result = await _repository.CreateAsync(item, cancellationToken)
             .ConfigureAwait(false);
 
         if (_cacheService != null)
-            await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}section:*")
+            await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}section:*", cancellationToken)
                 .ConfigureAwait(false);
 
         return result;
     }
 
-    public async Task DeleteAsync(int id)
+    public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
     {
-        await _repository.DeleteAsync(id).ConfigureAwait(false);
+        await _repository.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
 
         if (_cacheService != null)
-            await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}section:*")
+            await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}section:*", cancellationToken)
                 .ConfigureAwait(false);
     }
 }

--- a/suryami62.Application/Services/ProjectService.cs
+++ b/suryami62.Application/Services/ProjectService.cs
@@ -9,15 +9,18 @@ namespace suryami62.Services;
 
 public interface IProjectService
 {
-    Task<(List<Project> Items, int Total)> GetProjectsAsync(int? skip = null, int? take = null);
+    Task<(List<Project> Items, int Total)> GetProjectsAsync(
+        int? skip = null,
+        int? take = null,
+        CancellationToken cancellationToken = default);
 
-    Task<Project?> GetProjectByIdAsync(int id);
+    Task<Project?> GetProjectByIdAsync(int id, CancellationToken cancellationToken = default);
 
-    Task<Project> CreateProjectAsync(Project project);
+    Task<Project> CreateProjectAsync(Project project, CancellationToken cancellationToken = default);
 
-    Task UpdateProjectAsync(Project project);
+    Task UpdateProjectAsync(Project project, CancellationToken cancellationToken = default);
 
-    Task DeleteProjectAsync(int id);
+    Task DeleteProjectAsync(int id, CancellationToken cancellationToken = default);
 }
 
 public sealed class ProjectService : IProjectService
@@ -42,13 +45,16 @@ public sealed class ProjectService : IProjectService
         _stampedeProtection = stampedeProtection;
     }
 
-    public async Task<(List<Project> Items, int Total)> GetProjectsAsync(int? skip = null, int? take = null)
+    public async Task<(List<Project> Items, int Total)> GetProjectsAsync(
+        int? skip = null,
+        int? take = null,
+        CancellationToken cancellationToken = default)
     {
         var cacheKey = $"{CacheKeyPrefix}list:{skip ?? 0}:{take ?? 0}";
 
         if (_cacheService != null)
         {
-            var cached = await _cacheService.GetAsync<CachedProjectList>(cacheKey)
+            var cached = await _cacheService.GetAsync<CachedProjectList>(cacheKey, cancellationToken)
                 .ConfigureAwait(false);
 
             if (cached != null)
@@ -61,46 +67,48 @@ public sealed class ProjectService : IProjectService
                 .ExecuteAsync(cacheKey, async () =>
                 {
                     var doubleCheck = await _cacheService
-                        .GetAsync<CachedProjectList>(cacheKey)
+                        .GetAsync<CachedProjectList>(cacheKey, cancellationToken)
                         .ConfigureAwait(false);
 
                     if (doubleCheck != null) return (doubleCheck.Items, doubleCheck.Total);
 
                     var dbResult = await _repository
-                        .GetProjectsAsync(skip, take)
+                        .GetProjectsAsync(skip, take, cancellationToken)
                         .ConfigureAwait(false);
 
                     await _cacheService.SetAsync(
                         cacheKey,
                         new CachedProjectList(dbResult.Items, dbResult.Total),
-                        CacheExpiration).ConfigureAwait(false);
+                        CacheExpiration,
+                        cancellationToken).ConfigureAwait(false);
 
                     return dbResult;
-                }).ConfigureAwait(false);
+                }, cancellationToken).ConfigureAwait(false);
 
             return result;
         }
 
         var fallbackResult = await _repository
-            .GetProjectsAsync(skip, take)
+            .GetProjectsAsync(skip, take, cancellationToken)
             .ConfigureAwait(false);
 
         if (_cacheService != null)
             await _cacheService.SetAsync(
                 cacheKey,
                 new CachedProjectList(fallbackResult.Items, fallbackResult.Total),
-                CacheExpiration).ConfigureAwait(false);
+                CacheExpiration,
+                cancellationToken).ConfigureAwait(false);
 
         return fallbackResult;
     }
 
-    public async Task<Project?> GetProjectByIdAsync(int id)
+    public async Task<Project?> GetProjectByIdAsync(int id, CancellationToken cancellationToken = default)
     {
         var cacheKey = $"{CacheKeyPrefix}id:{id}";
 
         if (_cacheService != null)
         {
-            var cached = await _cacheService.GetAsync<Project>(cacheKey).ConfigureAwait(false);
+            var cached = await _cacheService.GetAsync<Project>(cacheKey, cancellationToken).ConfigureAwait(false);
             if (cached != null) return cached;
         }
 
@@ -109,68 +117,70 @@ public sealed class ProjectService : IProjectService
             var result = await _stampedeProtection
                 .ExecuteAsync(cacheKey, async () =>
                 {
-                    var doubleCheck = await _cacheService.GetAsync<Project>(cacheKey)
+                    var doubleCheck = await _cacheService.GetAsync<Project>(cacheKey, cancellationToken)
                         .ConfigureAwait(false);
                     if (doubleCheck != null) return doubleCheck;
 
-                    var project = await _repository.GetByIdAsync(id).ConfigureAwait(false);
+                    var project = await _repository.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
 
                     if (project != null)
-                        await _cacheService.SetAsync(cacheKey, project, CacheExpiration)
+                        await _cacheService.SetAsync(cacheKey, project, CacheExpiration, cancellationToken)
                             .ConfigureAwait(false);
 
                     return project;
-                }).ConfigureAwait(false);
+                }, cancellationToken).ConfigureAwait(false);
 
             return result;
         }
 
-        var fallbackProject = await _repository.GetByIdAsync(id).ConfigureAwait(false);
+        var fallbackProject = await _repository.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
 
         if (_cacheService != null && fallbackProject != null)
-            await _cacheService.SetAsync(cacheKey, fallbackProject, CacheExpiration)
+            await _cacheService.SetAsync(cacheKey, fallbackProject, CacheExpiration, cancellationToken)
                 .ConfigureAwait(false);
 
         return fallbackProject;
     }
 
-    public async Task<Project> CreateProjectAsync(Project project)
+    public async Task<Project> CreateProjectAsync(
+        Project project,
+        CancellationToken cancellationToken = default)
     {
-        var result = await _repository.CreateAsync(project).ConfigureAwait(false);
+        var result = await _repository.CreateAsync(project, cancellationToken).ConfigureAwait(false);
 
         if (_cacheService != null)
-            await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}list:*")
+            await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}list:*", cancellationToken)
                 .ConfigureAwait(false);
 
         return result;
     }
 
-    public async Task UpdateProjectAsync(Project project)
+    public async Task UpdateProjectAsync(Project project, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(project);
 
-        await _repository.UpdateAsync(project).ConfigureAwait(false);
+        await _repository.UpdateAsync(project, cancellationToken).ConfigureAwait(false);
 
         if (_cacheService != null)
         {
-            await _cacheService.RemoveEntryAsync($"{CacheKeyPrefix}id:{project.Id}")
+            await _cacheService.RemoveEntryAsync($"{CacheKeyPrefix}id:{project.Id}", cancellationToken)
                 .ConfigureAwait(false);
 
-            await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}list:*")
+            await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}list:*", cancellationToken)
                 .ConfigureAwait(false);
         }
     }
 
-    public async Task DeleteProjectAsync(int id)
+    public async Task DeleteProjectAsync(int id, CancellationToken cancellationToken = default)
     {
-        await _repository.DeleteAsync(id).ConfigureAwait(false);
+        await _repository.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
 
         if (_cacheService != null)
         {
-            await _cacheService.RemoveEntryAsync($"{CacheKeyPrefix}id:{id}")
+            await _cacheService.RemoveEntryAsync($"{CacheKeyPrefix}id:{id}", cancellationToken)
                 .ConfigureAwait(false);
 
-            await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}list:*")
+            await _cacheService.RemoveByPatternAsync($"{CacheKeyPrefix}list:*", cancellationToken)
                 .ConfigureAwait(false);
         }
     }

--- a/suryami62.Application/Services/SiteProfileSettingsStore.cs
+++ b/suryami62.Application/Services/SiteProfileSettingsStore.cs
@@ -99,7 +99,7 @@ public sealed class SiteProfileSettingsStore : ISiteProfileSettingsStore
                         .ConfigureAwait(false);
 
                     return settings;
-                }).ConfigureAwait(false);
+                }, cancellationToken).ConfigureAwait(false);
 
             return result;
         }

--- a/suryami62.Infrastructure/Persistence/BlogPostRepository.cs
+++ b/suryami62.Infrastructure/Persistence/BlogPostRepository.cs
@@ -25,40 +25,44 @@ public sealed class BlogPostRepository : IBlogPostRepository
         bool onlyPublished = true,
         int? skip = null,
         int? take = null,
-        string? searchTerm = null)
+        string? searchTerm = null,
+        CancellationToken cancellationToken = default)
     {
         var filteredPosts = CreateFilteredPostsQuery(onlyPublished, searchTerm);
 
-        var total = await filteredPosts.CountAsync().ConfigureAwait(false);
+        var total = await filteredPosts.CountAsync(cancellationToken).ConfigureAwait(false);
 
-        var items = await LoadPagedPostsAsync(filteredPosts, skip, take).ConfigureAwait(false);
+        var items = await LoadPagedPostsAsync(filteredPosts, skip, take, cancellationToken).ConfigureAwait(false);
 
         return (items, total);
     }
 
-    public async Task<BlogPost?> GetBySlugAsync(string slug)
+    public async Task<BlogPost?> GetBySlugAsync(string slug, CancellationToken cancellationToken = default)
     {
         EnsureSlug(slug);
 
         var post = await _context.BlogPosts
             .AsNoTracking()
-            .FirstOrDefaultAsync(post => post.Slug == slug)
+            .FirstOrDefaultAsync(post => post.Slug == slug, cancellationToken)
             .ConfigureAwait(false);
 
         return post;
     }
 
-    public async Task<BlogPost?> GetByIdAsync(int id)
+    public async Task<BlogPost?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
     {
         var post = await _context.BlogPosts
             .AsNoTracking()
-            .FirstOrDefaultAsync(post => post.Id == id)
+            .FirstOrDefaultAsync(post => post.Id == id, cancellationToken)
             .ConfigureAwait(false);
 
         return post;
     }
 
-    public async Task<bool> SlugExistsAsync(string slug, int? excludeId = null)
+    public async Task<bool> SlugExistsAsync(
+        string slug,
+        int? excludeId = null,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(slug))
             return false;
@@ -70,21 +74,21 @@ public sealed class BlogPostRepository : IBlogPostRepository
         if (excludeId.HasValue)
             query = query.Where(p => p.Id != excludeId.Value);
 
-        return await query.AnyAsync().ConfigureAwait(false);
+        return await query.AnyAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<BlogPost> CreateAsync(BlogPost post)
+    public async Task<BlogPost> CreateAsync(BlogPost post, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(post);
 
         _context.BlogPosts.Add(post);
 
-        await _context.SaveChangesAsync().ConfigureAwait(false);
+        await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         return post;
     }
 
-    public async Task UpdateAsync(BlogPost post)
+    public async Task UpdateAsync(BlogPost post, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(post);
 
@@ -94,20 +98,20 @@ public sealed class BlogPostRepository : IBlogPostRepository
             post,
             item => item.Id);
 
-        await _context.SaveChangesAsync().ConfigureAwait(false);
+        await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task DeleteAsync(int id)
+    public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
     {
         var post = await _context.BlogPosts
-            .FindAsync(id)
+            .FindAsync(new object[] { id }, cancellationToken)
             .ConfigureAwait(false);
 
         if (post is null) return;
 
         _context.BlogPosts.Remove(post);
 
-        await _context.SaveChangesAsync().ConfigureAwait(false);
+        await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private IQueryable<BlogPost> CreateFilteredPostsQuery(bool onlyPublished, string? searchTerm)
@@ -142,7 +146,8 @@ public sealed class BlogPostRepository : IBlogPostRepository
     private static async Task<List<BlogPost>> LoadPagedPostsAsync(
         IQueryable<BlogPost> filteredPosts,
         int? skip,
-        int? take)
+        int? take,
+        CancellationToken cancellationToken)
     {
         var sortedPosts = filteredPosts
             .OrderByDescending(post => post.Date);
@@ -150,7 +155,7 @@ public sealed class BlogPostRepository : IBlogPostRepository
         var pagedPosts = EfRepositoryHelpers
             .ApplyOptionalPaging(sortedPosts, skip, take);
 
-        return await pagedPosts.ToListAsync().ConfigureAwait(false);
+        return await pagedPosts.ToListAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private static void EnsureSlug(string slug)

--- a/suryami62.Infrastructure/Persistence/JourneyHistoryRepository.cs
+++ b/suryami62.Infrastructure/Persistence/JourneyHistoryRepository.cs
@@ -19,36 +19,40 @@ public sealed class JourneyHistoryRepository : IJourneyHistoryRepository
         _context = context;
     }
 
-    public Task<List<JourneyHistory>> GetBySectionAsync(JourneySection section)
+    public Task<List<JourneyHistory>> GetBySectionAsync(
+        JourneySection section,
+        CancellationToken cancellationToken = default)
     {
-        return GetOrderedSectionQuery(section).ToListAsync();
+        return GetOrderedSectionQuery(section).ToListAsync(cancellationToken);
     }
 
-    public async Task<JourneyHistory> CreateAsync(JourneyHistory item)
+    public async Task<JourneyHistory> CreateAsync(
+        JourneyHistory item,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(item);
 
-        item.DisplayOrder = await GetNextDisplayOrderAsync(item.Section)
+        item.DisplayOrder = await GetNextDisplayOrderAsync(item.Section, cancellationToken)
             .ConfigureAwait(false);
 
         _context.JourneyHistories.Add(item);
 
-        await _context.SaveChangesAsync().ConfigureAwait(false);
+        await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         return item;
     }
 
-    public async Task DeleteAsync(int id)
+    public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
     {
         var item = await _context.JourneyHistories
-            .FindAsync(id)
+            .FindAsync(new object[] { id }, cancellationToken)
             .ConfigureAwait(false);
 
         if (item is null) return;
 
         _context.JourneyHistories.Remove(item);
 
-        await _context.SaveChangesAsync().ConfigureAwait(false);
+        await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private IQueryable<JourneyHistory> GetOrderedSectionQuery(JourneySection section)
@@ -60,12 +64,14 @@ public sealed class JourneyHistoryRepository : IJourneyHistoryRepository
             .ThenBy(item => item.Id);
     }
 
-    private async Task<int> GetNextDisplayOrderAsync(JourneySection section)
+    private async Task<int> GetNextDisplayOrderAsync(
+        JourneySection section,
+        CancellationToken cancellationToken)
     {
         var maxOrder = await _context.JourneyHistories
             .Where(existing => existing.Section == section)
             .Select(existing => (int?)existing.DisplayOrder)
-            .MaxAsync()
+            .MaxAsync(cancellationToken)
             .ConfigureAwait(false);
 
         return (maxOrder ?? 0) + 1;

--- a/suryami62.Infrastructure/Persistence/ProjectRepository.cs
+++ b/suryami62.Infrastructure/Persistence/ProjectRepository.cs
@@ -19,40 +19,43 @@ public sealed class ProjectRepository : IProjectRepository
         _context = context;
     }
 
-    public async Task<(List<Project> Items, int Total)> GetProjectsAsync(int? skip = null, int? take = null)
+    public async Task<(List<Project> Items, int Total)> GetProjectsAsync(
+        int? skip = null,
+        int? take = null,
+        CancellationToken cancellationToken = default)
     {
         var projectsQuery = _context.Projects.AsNoTracking();
 
-        var total = await projectsQuery.CountAsync().ConfigureAwait(false);
+        var total = await projectsQuery.CountAsync(cancellationToken).ConfigureAwait(false);
 
-        var items = await LoadPagedProjectsAsync(projectsQuery, skip, take)
+        var items = await LoadPagedProjectsAsync(projectsQuery, skip, take, cancellationToken)
             .ConfigureAwait(false);
 
         return (items, total);
     }
 
-    public async Task<Project?> GetByIdAsync(int id)
+    public async Task<Project?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
     {
         var project = await _context.Projects
             .AsNoTracking()
-            .FirstOrDefaultAsync(p => p.Id == id)
+            .FirstOrDefaultAsync(p => p.Id == id, cancellationToken)
             .ConfigureAwait(false);
 
         return project;
     }
 
-    public async Task<Project> CreateAsync(Project project)
+    public async Task<Project> CreateAsync(Project project, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(project);
 
         _context.Projects.Add(project);
 
-        await _context.SaveChangesAsync().ConfigureAwait(false);
+        await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         return project;
     }
 
-    public async Task UpdateAsync(Project project)
+    public async Task UpdateAsync(Project project, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(project);
 
@@ -62,26 +65,27 @@ public sealed class ProjectRepository : IProjectRepository
             project,
             item => item.Id);
 
-        await _context.SaveChangesAsync().ConfigureAwait(false);
+        await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task DeleteAsync(int id)
+    public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
     {
         var project = await _context.Projects
-            .FindAsync(id)
+            .FindAsync(new object[] { id }, cancellationToken)
             .ConfigureAwait(false);
 
         if (project is null) return;
 
         _context.Projects.Remove(project);
 
-        await _context.SaveChangesAsync().ConfigureAwait(false);
+        await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private static Task<List<Project>> LoadPagedProjectsAsync(
         IQueryable<Project> projectsQuery,
         int? skip,
-        int? take)
+        int? take,
+        CancellationToken cancellationToken)
     {
         var orderedProjects = projectsQuery
             .OrderBy(project => project.DisplayOrder);
@@ -89,6 +93,6 @@ public sealed class ProjectRepository : IProjectRepository
         var pagedProjects = EfRepositoryHelpers
             .ApplyOptionalPaging(orderedProjects, skip, take);
 
-        return pagedProjects.ToListAsync();
+        return pagedProjects.ToListAsync(cancellationToken);
     }
 }

--- a/suryami62/Startup/SeoEndpointRouteBuilderExtensions.cs
+++ b/suryami62/Startup/SeoEndpointRouteBuilderExtensions.cs
@@ -27,16 +27,19 @@ internal static class SeoEndpointRouteBuilderExtensions
     private static async Task<IResult> GetSitemapAsync(
         IConfiguration configuration,
         SeoSettingsStore seoSettingsStore,
-        IBlogPostService blogPostService)
+        IBlogPostService blogPostService,
+        CancellationToken cancellationToken)
     {
-        var seoSettings = await seoSettingsStore.GetAsync().ConfigureAwait(false);
+        var seoSettings = await seoSettingsStore.GetAsync(cancellationToken).ConfigureAwait(false);
 
         if (!seoSettings.EnableSitemap) return Results.NotFound();
 
         var canonicalBaseUrl = GetCanonicalBaseUrl(configuration, seoSettings);
         if (canonicalBaseUrl is null) return CreateMissingCanonicalBaseUrlProblem("sitemap.xml");
 
-        (IEnumerable<BlogPost> posts, _) = await blogPostService.GetPostsAsync().ConfigureAwait(false);
+        (IEnumerable<BlogPost> posts, _) = await blogPostService
+            .GetPostsAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
 
         var sitemapXml = BuildSitemapXml(canonicalBaseUrl, posts);
         return Results.Text(sitemapXml, "application/xml; charset=utf-8");
@@ -44,9 +47,10 @@ internal static class SeoEndpointRouteBuilderExtensions
 
     private static async Task<IResult> GetRobotsAsync(
         IConfiguration configuration,
-        SeoSettingsStore seoSettingsStore)
+        SeoSettingsStore seoSettingsStore,
+        CancellationToken cancellationToken)
     {
-        var seoSettings = await seoSettingsStore.GetAsync().ConfigureAwait(false);
+        var seoSettings = await seoSettingsStore.GetAsync(cancellationToken).ConfigureAwait(false);
 
         if (!seoSettings.EnableRobots) return Results.NotFound();
 


### PR DESCRIPTION
Database and cache work kept running after callers abandoned requests, because repository and service APIs did not accept cancellation tokens.

This threads optional cancellation tokens through application services, repository contracts, EF Core async calls, cache operations, stampede protection waits, and SEO endpoint generation so cancelled requests can stop unnecessary work earlier.