### PR TITLE
fix(data): prevent silent overwrites on content edits

### DIFF
--- a/suryami62.Application/Persistence/ConcurrencyConflictException.cs
+++ b/suryami62.Application/Persistence/ConcurrencyConflictException.cs
@@ -1,0 +1,9 @@
+namespace suryami62.Application.Persistence;
+
+public sealed class ConcurrencyConflictException : InvalidOperationException
+{
+    public ConcurrencyConflictException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/suryami62.Domain/Models/BlogPost.cs
+++ b/suryami62.Domain/Models/BlogPost.cs
@@ -6,9 +6,11 @@ using System.ComponentModel.DataAnnotations;
 
 namespace suryami62.Domain.Models;
 
-public sealed class BlogPost
+public sealed class BlogPost : IConcurrencyTrackedEntity
 {
     public int Id { get; set; }
+
+    public uint Version { get; set; }
 
     [Required]
     [StringLength(DomainModelConstraints.TitleMaxLength)]

--- a/suryami62.Domain/Models/IConcurrencyTrackedEntity.cs
+++ b/suryami62.Domain/Models/IConcurrencyTrackedEntity.cs
@@ -1,0 +1,6 @@
+namespace suryami62.Domain.Models;
+
+public interface IConcurrencyTrackedEntity
+{
+    uint Version { get; set; }
+}

--- a/suryami62.Domain/Models/JourneyHistory.cs
+++ b/suryami62.Domain/Models/JourneyHistory.cs
@@ -15,9 +15,11 @@ public enum JourneySection
     Education = 2
 }
 
-public sealed class JourneyHistory
+public sealed class JourneyHistory : IConcurrencyTrackedEntity
 {
     public int Id { get; set; }
+
+    public uint Version { get; set; }
 
     public JourneySection Section { get; set; }
 

--- a/suryami62.Domain/Models/Project.cs
+++ b/suryami62.Domain/Models/Project.cs
@@ -6,9 +6,11 @@ using System.ComponentModel.DataAnnotations;
 
 namespace suryami62.Domain.Models;
 
-public sealed class Project
+public sealed class Project : IConcurrencyTrackedEntity
 {
     public int Id { get; set; }
+
+    public uint Version { get; set; }
 
     [Required]
     [StringLength(DomainModelConstraints.TitleMaxLength)]

--- a/suryami62.Domain/Models/Setting.cs
+++ b/suryami62.Domain/Models/Setting.cs
@@ -6,9 +6,11 @@ using System.ComponentModel.DataAnnotations;
 
 namespace suryami62.Domain.Models;
 
-public sealed class Setting
+public sealed class Setting : IConcurrencyTrackedEntity
 {
     public int Id { get; set; }
+
+    public uint Version { get; set; }
 
     [Required]
     [StringLength(DomainModelConstraints.SettingKeyMaxLength)]

--- a/suryami62.Infrastructure/Data/ApplicationDbContext.cs
+++ b/suryami62.Infrastructure/Data/ApplicationDbContext.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using suryami62.Domain.Models;
 
@@ -54,6 +55,8 @@ public sealed class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 
         builder.Entity<Project>(entity =>
         {
+            ConfigureXminConcurrencyToken(entity);
+
             entity.Property(p => p.RepoUrl).HasConversion(uriConverter);
             entity.Property(p => p.DemoUrl).HasConversion(uriConverter);
             entity.Property(p => p.ImageUrl).HasConversion(uriConverter);
@@ -63,6 +66,8 @@ public sealed class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 
         builder.Entity<BlogPost>(entity =>
         {
+            ConfigureXminConcurrencyToken(entity);
+
             entity.Property(p => p.Date).HasColumnType("timestamp with time zone");
             entity.Property(p => p.ImageUrl).HasConversion(uriConverter);
 
@@ -74,6 +79,8 @@ public sealed class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 
         builder.Entity<JourneyHistory>(entity =>
         {
+            ConfigureXminConcurrencyToken(entity);
+
             entity.Property(item => item.Summary).HasDefaultValue(string.Empty);
 
             entity.HasIndex(item => new { item.Section, item.DisplayOrder });
@@ -81,8 +88,20 @@ public sealed class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 
         builder.Entity<Setting>(entity =>
         {
+            ConfigureXminConcurrencyToken(entity);
+
             entity.HasIndex(setting => setting.Key).IsUnique();
         });
+    }
+
+    private static void ConfigureXminConcurrencyToken<TEntity>(EntityTypeBuilder<TEntity> entity)
+        where TEntity : class, IConcurrencyTrackedEntity
+    {
+        entity.Property(item => item.Version)
+            .HasColumnName("xmin")
+            .HasColumnType("xid")
+            .ValueGeneratedOnAddOrUpdate()
+            .IsConcurrencyToken();
     }
 
     private static Uri? ParseAbsoluteUri(string? value)

--- a/suryami62.Infrastructure/Data/Migrations/20260530091601_AddOptimisticConcurrencyTokens.Designer.cs
+++ b/suryami62.Infrastructure/Data/Migrations/20260530091601_AddOptimisticConcurrencyTokens.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using suryami62.Data;
@@ -11,9 +12,11 @@ using suryami62.Data;
 namespace suryami62.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260530091601_AddOptimisticConcurrencyTokens")]
+    partial class AddOptimisticConcurrencyTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/suryami62.Infrastructure/Data/Migrations/20260530091601_AddOptimisticConcurrencyTokens.cs
+++ b/suryami62.Infrastructure/Data/Migrations/20260530091601_AddOptimisticConcurrencyTokens.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace suryami62.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOptimisticConcurrencyTokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            ArgumentNullException.ThrowIfNull(migrationBuilder);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            ArgumentNullException.ThrowIfNull(migrationBuilder);
+        }
+    }
+}

--- a/suryami62.Infrastructure/Persistence/BlogPostRepository.cs
+++ b/suryami62.Infrastructure/Persistence/BlogPostRepository.cs
@@ -92,13 +92,22 @@ public sealed class BlogPostRepository : IBlogPostRepository
     {
         ArgumentNullException.ThrowIfNull(post);
 
-        EfRepositoryHelpers.UpdateExistingOrAttachModified(
-            _context,
-            _context.BlogPosts,
-            post,
-            item => item.Id);
+        try
+        {
+            EfRepositoryHelpers.UpdateExistingOrAttachModified(
+                _context,
+                _context.BlogPosts,
+                post,
+                item => item.Id);
 
-        await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            throw new ConcurrencyConflictException(
+                "The blog post was changed by another user. Reload it before saving again.",
+                ex);
+        }
     }
 
     public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)

--- a/suryami62.Infrastructure/Persistence/EfRepositoryHelpers.cs
+++ b/suryami62.Infrastructure/Persistence/EfRepositoryHelpers.cs
@@ -1,6 +1,8 @@
 #region
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using suryami62.Domain.Models;
 
 #endregion
 
@@ -41,11 +43,32 @@ internal static class EfRepositoryHelpers
 
         if (trackedEntity is not null && !ReferenceEquals(trackedEntity, entity))
         {
-            context.Entry(trackedEntity).CurrentValues.SetValues(entity);
+            var trackedEntry = context.Entry(trackedEntity);
+
+            trackedEntry.CurrentValues.SetValues(entity);
+            ApplyOriginalConcurrencyVersion(trackedEntry, entity);
             return;
         }
 
         if (trackedEntity is null)
-            context.Entry(entity).State = EntityState.Modified;
+        {
+            var entry = context.Entry(entity);
+
+            entry.State = EntityState.Modified;
+            ApplyOriginalConcurrencyVersion(entry, entity);
+        }
+    }
+
+    private static void ApplyOriginalConcurrencyVersion<TEntity>(
+        EntityEntry<TEntity> entry,
+        TEntity entity)
+        where TEntity : class
+    {
+        if (entity is not IConcurrencyTrackedEntity concurrencyTrackedEntity) return;
+
+        var versionProperty = entry.Property(nameof(IConcurrencyTrackedEntity.Version));
+
+        versionProperty.OriginalValue = concurrencyTrackedEntity.Version;
+        versionProperty.IsModified = false;
     }
 }

--- a/suryami62.Infrastructure/Persistence/ProjectRepository.cs
+++ b/suryami62.Infrastructure/Persistence/ProjectRepository.cs
@@ -59,13 +59,22 @@ public sealed class ProjectRepository : IProjectRepository
     {
         ArgumentNullException.ThrowIfNull(project);
 
-        EfRepositoryHelpers.UpdateExistingOrAttachModified(
-            _context,
-            _context.Projects,
-            project,
-            item => item.Id);
+        try
+        {
+            EfRepositoryHelpers.UpdateExistingOrAttachModified(
+                _context,
+                _context.Projects,
+                project,
+                item => item.Id);
 
-        await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            throw new ConcurrencyConflictException(
+                "The project was changed by another user. Reload it before saving again.",
+                ex);
+        }
     }
 
     public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)

--- a/suryami62/Components/Account/Pages/Admin/EditPost.razor
+++ b/suryami62/Components/Account/Pages/Admin/EditPost.razor
@@ -1,6 +1,7 @@
 ﻿@page "/Account/Admin/Posts/New"
 @page "/Account/Admin/Posts/Edit/{Id:int}"
 @using Microsoft.AspNetCore.Authorization
+@using suryami62.Application.Persistence
 @using suryami62.Domain.Models
 @attribute [Authorize(Policy = AdminAccessPolicy.Name)]
 @rendermode InteractiveServer
@@ -11,6 +12,20 @@
 
 <div class="flex flex-col gap-12 py-8">
     <PageHeader Title="@PageActionText" Highlight="Post"/>
+
+    @if (HasStatusMessage)
+    {
+        <div class="@StatusMessageClass" role="alert">
+            <p>@_statusMessage</p>
+
+            @if (CanReloadAfterConflict)
+            {
+                <button type="button" @onclick="ReloadPostAsync" class="@ReloadButtonClass">
+                    RELOAD POST
+                </button>
+            }
+        </div>
+    }
 
     <EditForm Model="@_post" OnValidSubmit="SavePostAsync" FormName="edit-post-form"
               class="neo-card flex flex-col gap-6 p-8">
@@ -97,12 +112,22 @@
     private const string ValidationSummaryClass = "mb-4 font-bold text-red-600 dark:text-red-400";
     private const string PrimaryButtonClass = "neo-button-lime px-8 py-3 text-xl";
     private const string SecondaryButtonClass = "neo-button bg-neutral-200 px-8 py-3 text-xl hover:bg-neutral-300 dark:bg-neutral-700 dark:text-white dark:hover:bg-neutral-600";
+    private const string ReloadButtonClass = "neo-button mt-3 px-4 py-2 text-sm";
 
     [Parameter] public int? Id { get; set; }
 
     private BlogPost _post = CreateNewPost();
     private string? _imageUrlText;
+    private string? _statusMessage;
     private bool _isSubmitting;
+    private bool _hasConcurrencyConflict;
+
+    private string StatusMessageClass =>
+        $"neo-card p-4 font-bold {(_hasConcurrencyConflict ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200" : "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300")}";
+
+    private bool HasStatusMessage => !string.IsNullOrWhiteSpace(_statusMessage);
+
+    private bool CanReloadAfterConflict => _hasConcurrencyConflict && !IsNewPost;
 
     private bool IsNewPost => Id is null;
 
@@ -143,7 +168,7 @@
         var title = e.Value?.ToString();
 
         // Generate unique slug via service (handles duplicates with -2, -3, etc.)
-        _post.Slug = await BlogPostService.GenerateUniqueSlugAsync(title);
+        _post.Slug = await BlogPostService.GenerateUniqueSlugAsync(title ?? string.Empty);
     }
 
     private async Task SavePostAsync()
@@ -161,9 +186,13 @@
             await PersistPostAsync();
             NavigateToPostList();
         }
+        catch (ConcurrencyConflictException ex)
+        {
+            SetConflictStatus(ex.Message);
+        }
         catch
         {
-            // Intentionally swallowing here keeps the page state intact so the user can correct input and retry.
+            SetErrorStatus("Failed to save post. Check the form and try again.");
         }
         finally
         {
@@ -196,6 +225,7 @@
     private void BeginSubmit()
     {
         _isSubmitting = true;
+        ClearStatus();
     }
 
     private void ApplyImageUrlInputToPost()
@@ -213,6 +243,35 @@
     private async Task UpdatePostAsync()
     {
         await BlogPostService.UpdatePostAsync(_post);
+    }
+
+    private async Task ReloadPostAsync()
+    {
+        if (IsNewPost)
+        {
+            return;
+        }
+
+        await LoadExistingPostAsync(Id!.Value);
+        ClearStatus();
+    }
+
+    private void ClearStatus()
+    {
+        _statusMessage = null;
+        _hasConcurrencyConflict = false;
+    }
+
+    private void SetConflictStatus(string message)
+    {
+        _statusMessage = message;
+        _hasConcurrencyConflict = true;
+    }
+
+    private void SetErrorStatus(string message)
+    {
+        _statusMessage = message;
+        _hasConcurrencyConflict = false;
     }
 
     private void NavigateToPostList()

--- a/suryami62/Components/Account/Pages/Admin/EditProject.razor
+++ b/suryami62/Components/Account/Pages/Admin/EditProject.razor
@@ -1,6 +1,7 @@
 ﻿@page "/Account/Admin/Projects/New"
 @page "/Account/Admin/Projects/Edit/{Id:int}"
 @using Microsoft.AspNetCore.Authorization
+@using suryami62.Application.Persistence
 @using suryami62.Domain.Models
 @attribute [Authorize(Policy = AdminAccessPolicy.Name)]
 @rendermode InteractiveServer
@@ -11,6 +12,20 @@
 
 <div class="flex flex-col gap-12 py-8">
     <PageHeader Title="@PageActionText" Highlight="Project"/>
+
+    @if (HasStatusMessage)
+    {
+        <div class="@StatusMessageClass" role="alert">
+            <p>@_statusMessage</p>
+
+            @if (CanReloadAfterConflict)
+            {
+                <button type="button" @onclick="ReloadProjectAsync" class="@ReloadButtonClass">
+                    RELOAD PROJECT
+                </button>
+            }
+        </div>
+    }
 
     <EditForm Model="@_project" OnValidSubmit="SaveProjectAsync" FormName="edit-project-form" method="post"
               class="neo-card flex flex-col gap-6 p-8">
@@ -90,6 +105,7 @@
     private const string ValidationSummaryClass = "mb-4 font-bold text-red-600 dark:text-red-400";
     private const string PrimaryButtonClass = "neo-button-orange px-8 py-3 text-xl";
     private const string SecondaryButtonClass = "neo-button bg-neutral-200 px-8 py-3 text-xl hover:bg-neutral-300 dark:bg-neutral-700 dark:text-white dark:hover:bg-neutral-600";
+    private const string ReloadButtonClass = "neo-button mt-3 px-4 py-2 text-sm";
 
     [Parameter] public int? Id { get; set; }
 
@@ -97,7 +113,16 @@
     private string? _repoUrlText;
     private string? _demoUrlText;
     private string? _imageUrlText;
+    private string? _statusMessage;
     private bool _isSubmitting;
+    private bool _hasConcurrencyConflict;
+
+    private string StatusMessageClass =>
+        $"neo-card p-4 font-bold {(_hasConcurrencyConflict ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200" : "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300")}";
+
+    private bool HasStatusMessage => !string.IsNullOrWhiteSpace(_statusMessage);
+
+    private bool CanReloadAfterConflict => _hasConcurrencyConflict && !IsNewProject;
 
     private bool IsNewProject => Id is null;
 
@@ -173,9 +198,13 @@
             await PersistProjectAsync();
             NavigateToProjectList();
         }
+        catch (ConcurrencyConflictException ex)
+        {
+            SetConflictStatus(ex.Message);
+        }
         catch
         {
-            // Keeping the current form state after a failed save gives the user a chance to correct and retry.
+            SetErrorStatus("Failed to save project. Check the form and try again.");
         }
         finally
         {
@@ -186,6 +215,7 @@
     private void BeginSubmit()
     {
         _isSubmitting = true;
+        ClearStatus();
     }
 
     private void ApplyUrlInputsToProject()
@@ -205,6 +235,35 @@
     private async Task UpdateProjectAsync()
     {
         await ProjectService.UpdateProjectAsync(_project);
+    }
+
+    private async Task ReloadProjectAsync()
+    {
+        if (IsNewProject)
+        {
+            return;
+        }
+
+        await LoadExistingProjectAsync(Id!.Value);
+        ClearStatus();
+    }
+
+    private void ClearStatus()
+    {
+        _statusMessage = null;
+        _hasConcurrencyConflict = false;
+    }
+
+    private void SetConflictStatus(string message)
+    {
+        _statusMessage = message;
+        _hasConcurrencyConflict = true;
+    }
+
+    private void SetErrorStatus(string message)
+    {
+        _statusMessage = message;
+        _hasConcurrencyConflict = false;
     }
 
     private void NavigateToProjectList()


### PR DESCRIPTION
Admin-edited rows could be saved from stale form state with no warning, letting the last save overwrite changes from another tab or admin session.

This maps content entities to PostgreSQL xmin concurrency tokens, preserves the original token during detached EF updates, and surfaces conflicts in the admin edit pages with a reload path.