### PR TITLE
fix(projects): normalize project tags before persistence

### DIFF
--- a/suryami62.Application/Services/ProjectService.cs
+++ b/suryami62.Application/Services/ProjectService.cs
@@ -146,6 +146,10 @@ public sealed class ProjectService : IProjectService
         Project project,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(project);
+
+        NormalizeProjectTags(project);
+
         var result = await _repository.CreateAsync(project, cancellationToken).ConfigureAwait(false);
 
         if (_cacheService != null)
@@ -158,6 +162,8 @@ public sealed class ProjectService : IProjectService
     public async Task UpdateProjectAsync(Project project, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(project);
+
+        NormalizeProjectTags(project);
 
         await _repository.UpdateAsync(project, cancellationToken).ConfigureAwait(false);
 
@@ -186,4 +192,17 @@ public sealed class ProjectService : IProjectService
     }
 
     private sealed record CachedProjectList(List<Project> Items, int Total);
+
+    private static void NormalizeProjectTags(Project project)
+    {
+        var validationResult = ProjectTagFormatter.Validate(project.Tags);
+        if (validationResult is not null)
+        {
+            throw new ArgumentException(
+                validationResult.ErrorMessage ?? "Project tags are invalid.",
+                nameof(project));
+        }
+
+        project.Tags = ProjectTagFormatter.Format(project.Tags);
+    }
 }

--- a/suryami62.Domain/Models/Project.cs
+++ b/suryami62.Domain/Models/Project.cs
@@ -6,7 +6,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace suryami62.Domain.Models;
 
-public sealed class Project : IConcurrencyTrackedEntity
+public sealed class Project : IConcurrencyTrackedEntity, IValidatableObject
 {
     public int Id { get; set; }
 
@@ -27,4 +27,13 @@ public sealed class Project : IConcurrencyTrackedEntity
     public Uri? ImageUrl { get; set; }
 
     public int DisplayOrder { get; set; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        var tagsValidationResult = ProjectTagFormatter.Validate(Tags);
+        if (tagsValidationResult is not null)
+        {
+            yield return tagsValidationResult;
+        }
+    }
 }

--- a/suryami62.Domain/Models/ProjectTagFormatter.cs
+++ b/suryami62.Domain/Models/ProjectTagFormatter.cs
@@ -1,0 +1,84 @@
+#region
+
+using System.ComponentModel.DataAnnotations;
+
+#endregion
+
+namespace suryami62.Domain.Models;
+
+public static class ProjectTagFormatter
+{
+    public const int MaxTagCount = 20;
+
+    public const int MaxTagLength = 40;
+
+    public static string[] Split(string? tags)
+    {
+        if (string.IsNullOrWhiteSpace(tags))
+        {
+            return Array.Empty<string>();
+        }
+
+        var normalizedTags = new List<string>();
+        var seenTags = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var rawTag in tags.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var normalizedTag = NormalizeWhitespace(rawTag);
+            if (normalizedTag.Length == 0 || !seenTags.Add(normalizedTag))
+            {
+                continue;
+            }
+
+            normalizedTags.Add(normalizedTag);
+        }
+
+        return normalizedTags.ToArray();
+    }
+
+    public static string Format(string? tags)
+    {
+        return string.Join(", ", Split(tags));
+    }
+
+    public static ValidationResult? Validate(string? tags)
+    {
+        if (ContainsUnsupportedControlCharacter(tags))
+        {
+            return new ValidationResult(
+                "Project tags cannot contain control characters.",
+                [nameof(Project.Tags)]);
+        }
+
+        var normalizedTags = Split(tags);
+        if (normalizedTags.Length > MaxTagCount)
+        {
+            return new ValidationResult(
+                $"Use {MaxTagCount} or fewer project tags.",
+                [nameof(Project.Tags)]);
+        }
+
+        var longTag = normalizedTags.FirstOrDefault(tag => tag.Length > MaxTagLength);
+        if (longTag is not null)
+        {
+            return new ValidationResult(
+                $"Project tag '{longTag}' must be {MaxTagLength} characters or fewer.",
+                [nameof(Project.Tags)]);
+        }
+
+        return null;
+    }
+
+    private static string NormalizeWhitespace(string value)
+    {
+        var normalizedParts = value
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        return string.Join(' ', normalizedParts);
+    }
+
+    private static bool ContainsUnsupportedControlCharacter(string? value)
+    {
+        return value is not null && value.Any(character => char.IsControl(character) && !char.IsWhiteSpace(character));
+    }
+}

--- a/suryami62/Components/Account/Pages/Admin/EditProject.razor
+++ b/suryami62/Components/Account/Pages/Admin/EditProject.razor
@@ -46,6 +46,7 @@
 
                 <InputText @bind-Value="_project.Tags" placeholder="e.g. .NET, Blazor, Tailwind"
                            class="@InputClass"/>
+                <ValidationMessage For="() => _project.Tags" class="font-bold text-red-600 dark:text-red-400"/>
             </div>
         </div>
 
@@ -201,6 +202,10 @@
         catch (ConcurrencyConflictException ex)
         {
             SetConflictStatus(ex.Message);
+        }
+        catch (ArgumentException ex)
+        {
+            SetErrorStatus(ex.Message);
         }
         catch
         {

--- a/suryami62/Components/Account/Pages/Admin/ManageProjects.razor
+++ b/suryami62/Components/Account/Pages/Admin/ManageProjects.razor
@@ -191,9 +191,7 @@
 
     private IEnumerable<string> GetProjectTags(Project project)
     {
-        return project.Tags
-            .Split(',', StringSplitOptions.RemoveEmptyEntries)
-            .Select(tag => tag.Trim());
+        return ProjectTagFormatter.Split(project.Tags);
     }
 
     private async Task<bool> ShouldDeleteProjectAsync()

--- a/suryami62/Components/Pages/Projects.razor
+++ b/suryami62/Components/Pages/Projects.razor
@@ -42,7 +42,7 @@
                 {
                     <ProjectCard Title="@project.Title"
                                  Description="@project.Description"
-                                 Tags="@GetTagsArray(project.Tags)"
+                                 Tags="@ProjectTagFormatter.Split(project.Tags)"
                                  RepoUrl="@GetUrlString(project.RepoUrl)"
                                  DemoUrl="@GetUrlString(project.DemoUrl)"
                                  ImageUrl="@GetUrlString(project.ImageUrl)"/>
@@ -139,19 +139,6 @@
     {
         _page = newPage;
         await LoadProjects();
-    }
-
-    private string[] GetTagsArray(string? tags)
-    {
-        if (string.IsNullOrWhiteSpace(tags))
-        {
-            return Array.Empty<string>();
-        }
-
-        return tags.Split(
-            ',',
-            StringSplitOptions.RemoveEmptyEntries
-        );
     }
 
     private string? GetUrlString(Uri? url)


### PR DESCRIPTION
Project tags were stored as free-form comma-separated text, which made spacing, duplicates, and display behavior depend on whichever page parsed the value.

Add a shared tag formatter and model validation so tags stay simple to store while create, update, and display paths all apply the same rules.